### PR TITLE
feat(splits): add literature-grounded splitters, sorters, and citations

### DIFF
--- a/splytters/__init__.py
+++ b/splytters/__init__.py
@@ -15,11 +15,14 @@ Modules:
 from splytters._types import Splitter
 from splytters.adversarial import (
     centroid_adversarial_split,
+    cluster_kfold,
     cluster_split,
     density_adversarial_split,
     distance_adversarial_split,
     get_cluster_info,
     min_cut_split,
+    minority_split,
+    mmd_maximized_split,
     normalized_cut_split,
     outlier_adversarial_split,
     wasserstein_adversarial_split,
@@ -91,7 +94,11 @@ __all__ = [
     "min_cut_split",
     "normalized_cut_split",
     "wasserstein_adversarial_split",
+    "mmd_maximized_split",
+    "minority_split",
     "get_cluster_info",
+    # Clustering-based challenging cross-validation (returns per-sample fold ids)
+    "cluster_kfold",
     # Overlap (maximize similarity)
     "cluster_leak_split",
     "neighbor_coverage_split",
@@ -154,6 +161,8 @@ _SPLITTER_FAMILIES: dict[str, list[str]] = {
         "min_cut_split",
         "normalized_cut_split",
         "wasserstein_adversarial_split",
+        "mmd_maximized_split",
+        "minority_split",
     ],
     "overlap": [
         "cluster_leak_split",

--- a/splytters/adversarial.py
+++ b/splytters/adversarial.py
@@ -21,11 +21,155 @@ from sklearn.utils import check_random_state
 
 from splytters.utils import (
     as_index_array,
-    cluster_embeddings,
     compute_centroid,
+    optimized_split,
     resolve_n_train,
     validate_split_inputs,
 )
+
+
+def _cluster_centroids(
+    embeddings: np.ndarray, cluster_to_indices: dict[int, list[int]]
+) -> dict[int, np.ndarray]:
+    """Mean embedding (centroid) of each cluster's members."""
+    return {cid: embeddings[idxs].mean(axis=0) for cid, idxs in cluster_to_indices.items()}
+
+
+def _assign_by_size(
+    cluster_to_indices: dict[int, list[int]], target_train: int
+) -> tuple[list[int], list[int]]:
+    """Greedily fill train with the largest clusters first (DBSCAN noise -> test)."""
+    clusters_by_size = sorted(
+        cluster_to_indices.items(), key=lambda kv: len(kv[1]), reverse=True
+    )
+    train: list[int] = []
+    test: list[int] = []
+    for cluster_id, indices in clusters_by_size:
+        if cluster_id == -1:  # DBSCAN noise points -> test
+            test.extend(indices)
+        elif len(train) + len(indices) <= target_train:
+            train.extend(indices)
+        else:
+            test.extend(indices)
+    return train, test
+
+
+def _assign_by_centroid(
+    embeddings: np.ndarray, cluster_to_indices: dict[int, list[int]], target_train: int
+) -> tuple[list[int], list[int]]:
+    """Rank clusters by distance from the global centroid; near -> train, far -> test."""
+    global_centroid = compute_centroid(embeddings)
+    centroids = _cluster_centroids(embeddings, cluster_to_indices)
+    ranked = sorted(
+        cluster_to_indices, key=lambda cid: np.linalg.norm(centroids[cid] - global_centroid)
+    )
+    train: list[int] = []
+    test: list[int] = []
+    for cid in ranked:
+        indices = cluster_to_indices[cid]
+        if len(train) + len(indices) <= target_train:
+            train.extend(indices)
+        else:
+            test.extend(indices)
+    return train, test
+
+
+def _assign_closest(
+    embeddings: np.ndarray, cluster_to_indices: dict[int, list[int]], target_test: int
+) -> tuple[list[int], list[int]]:
+    """CLOSEST-SPLIT: build one coherent, isolated test pocket in latent space.
+
+    Seed with the most isolated cluster (largest mean cosine distance to the
+    other cluster centroids), then grow the test set by repeatedly adding the
+    remaining cluster nearest (cosine) to the current test pocket, stopping
+    before the target test size is exceeded.
+    """
+    cids = list(cluster_to_indices)
+    centroids = _cluster_centroids(embeddings, cluster_to_indices)
+    sizes = [len(cluster_to_indices[cid]) for cid in cids]
+
+    # Pairwise cosine distances between cluster centroids (rows/cols aligned to cids).
+    C = np.vstack([centroids[cid] for cid in cids])
+    cos = cdist(C, C, metric="cosine")
+    isolation = cos.mean(axis=1)  # mean distance from each cluster to all others
+
+    # Seed: most isolated cluster that fits the target (else just the most isolated).
+    order = sorted(range(len(cids)), key=lambda j: isolation[j], reverse=True)
+    seed = next((j for j in order if sizes[j] <= target_test), order[0])
+
+    test_pos = {seed}
+    test_size = sizes[seed]
+    while test_size < target_test:
+        remaining = [j for j in range(len(cids)) if j not in test_pos]
+        if not remaining:
+            break
+        members = list(test_pos)
+        nearest = min(remaining, key=lambda j: cos[j, members].mean())
+        if test_size + sizes[nearest] > target_test:
+            break
+        test_pos.add(nearest)
+        test_size += sizes[nearest]
+
+    test_cids = {cids[j] for j in test_pos}
+    train: list[int] = []
+    test: list[int] = []
+    for cid, indices in cluster_to_indices.items():
+        (test if cid in test_cids else train).extend(indices)
+    return train, test
+
+
+def _assign_subset_sum(
+    cluster_to_indices: dict[int, list[int]],
+    y: np.ndarray,
+    target_test: int,
+    n_samples: int,
+) -> tuple[list[int], list[int]]:
+    """SUBSET-SUM-SPLIT: pick clusters whose pooled per-class counts best match a
+    class-balanced target test set.
+
+    Each cluster contributes a per-class count vector; we greedily select the
+    subset of clusters whose summed vector is closest (L1) to the target vector
+    ``target_test * class_proportions`` -- an approximate multidimensional
+    subset-sum keeping the test set's label distribution close to the whole.
+    """
+    classes = np.unique(y)
+    class_idx = {c: k for k, c in enumerate(classes)}
+
+    cids = list(cluster_to_indices)
+    vecs: dict[int, np.ndarray] = {}
+    for cid, idxs in cluster_to_indices.items():
+        v = np.zeros(len(classes))
+        labels_here, counts = np.unique(y[idxs], return_counts=True)
+        for c, cnt in zip(labels_here, counts):
+            v[class_idx[c]] = cnt
+        vecs[cid] = v
+
+    global_counts = np.array([np.sum(y == c) for c in classes], dtype=float)
+    target = target_test * global_counts / n_samples
+
+    selected: list[int] = []
+    current = np.zeros(len(classes))
+    remaining = set(cids)
+    best_dist = float(np.abs(current - target).sum())
+    while remaining:
+        cid = min(remaining, key=lambda c: float(np.abs(current + vecs[c] - target).sum()))
+        new_dist = float(np.abs(current + vecs[cid] - target).sum())
+        if new_dist >= best_dist:
+            break
+        selected.append(cid)
+        current = current + vecs[cid]
+        best_dist = new_dist
+        remaining.discard(cid)
+
+    if not selected:  # fall back to the single best-matching cluster
+        selected = [min(cids, key=lambda c: float(np.abs(vecs[c] - target).sum()))]
+
+    test_cids = set(selected)
+    train: list[int] = []
+    test: list[int] = []
+    for cid, indices in cluster_to_indices.items():
+        (test if cid in test_cids else train).extend(indices)
+    return train, test
 
 
 def cluster_split(
@@ -34,33 +178,98 @@ def cluster_split(
     method: str = "kmeans",
     n_clusters: int = 10,
     random_state: int = 42,
+    *,
+    strategy: str = "size",
+    y: ArrayLike | None = None,
     **cluster_kwargs: Any,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Split dataset by assigning entire clusters to train or test.
 
-    Prevents 'cluster leakage' where similar samples end up on both sides.
+    Prevents 'cluster leakage' where similar samples end up on both sides. The
+    embeddings are clustered (``method``), then whole clusters are assigned to
+    train/test according to ``strategy``.
 
     Args:
         embeddings: array-like of shape (n_samples, embedding_dim)
         train_size: fraction in (0, 1) or absolute count for the training set
-        method: 'kmeans' or 'dbscan'
+        method: clustering algorithm, 'kmeans' or 'dbscan'
         n_clusters: number of clusters (kmeans only)
         random_state: for reproducibility
-        **cluster_kwargs: passed to clustering algorithm
+        strategy: cluster -> train/test assignment policy:
+            - ``"size"`` (default): greedily fill train with the largest clusters
+              until the target ratio is met. The original, target-ratio-driven
+              behavior; DBSCAN noise points go to test.
+            - ``"centroid"``: rank clusters by distance from the global centroid,
+              nearest -> train, farthest -> test (adversarial). This is what
+              :func:`centroid_adversarial_split` delegates to.
+            - ``"subset_sum"``: select a subset of clusters whose pooled per-class
+              counts best match a class-balanced target test set. Requires ``y``.
+            - ``"closest"``: seed the most isolated cluster and grow it by
+              nearest-neighbor into a single coherent test "pocket" (adversarial).
+        y: class labels of shape (n_samples,). Required for ``strategy="subset_sum"``;
+            ignored by the other strategies.
+        **cluster_kwargs: passed to the clustering algorithm
 
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Raises:
+        ValueError: on an unknown ``method`` or ``strategy``, or if
+            ``strategy="subset_sum"`` is used without a valid ``y``.
+
+    References:
+        The ``"subset_sum"`` and ``"closest"`` strategies implement SUBSET-SUM-SPLIT
+        and CLOSEST-SPLIT from Züfle, Dankers & Titov (2023), "Latent Feature-based
+        Data Splits to Improve Generalisation Evaluation," GenBench Workshop @ EMNLP,
+        pp. 112-129. https://aclanthology.org/2023.genbench-1.9 . They cluster a
+        model's hidden representations and assign whole clusters to test to expose
+        latent-space "blind spots"; their analysis finds that the resulting
+        difficulty does not correlate with surface-level properties (e.g. length),
+        complementing the surface-based :mod:`splytters.sorters`.
+
+        The label-balanced idea behind ``"subset_sum"`` traces to the earlier
+        ClusterDataSplit of Wecker, Friedrich & Adel (2020), "ClusterDataSplit:
+        Exploring Challenging Clustering-Based Data Splits for Model Performance
+        Evaluation," Eval4NLP @ COLING, which clusters data into splits that
+        differ lexically from train while keeping the label distribution fixed.
+        https://aclanthology.org/2020.eval4nlp-1.15 . See :func:`cluster_kfold`
+        for their cross-validation variant.
+
+        Napoli & White (2025), "Clustering-Based Validation Splits for Model
+        Selection under Domain Shift," TMLR, ground this family theoretically:
+        maximizing the MMD between the two sets is equivalent to kernel k-means
+        clustering (k=2), and they replace ClusterDataSplit's greedy
+        class-balancing with a linear program (with convergence guarantees).
+        https://openreview.net/forum?id=Q692C0WtiD . See
+        :func:`mmd_maximized_split` for the MMD-maximizing objective.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
+
+    valid_strategies = {"size", "centroid", "subset_sum", "closest"}
+    if strategy not in valid_strategies:
+        raise ValueError(
+            f"Unknown strategy: {strategy!r}. Choose from {sorted(valid_strategies)}"
+        )
+
+    n_samples = len(embeddings)
+
+    if strategy == "subset_sum":
+        if y is None:
+            raise ValueError("strategy='subset_sum' requires class labels `y`")
+        y = np.asarray(y)
+        if len(y) != n_samples:
+            raise ValueError(
+                f"y has length {len(y)} but embeddings has {n_samples} rows"
+            )
 
     if method == "kmeans":
         clusterer = KMeans(
             n_clusters=n_clusters,
             random_state=random_state,
             n_init="auto",
-            **cluster_kwargs
+            **cluster_kwargs,
         )
     elif method == "dbscan":
         clusterer = DBSCAN(**cluster_kwargs)
@@ -68,38 +277,23 @@ def cluster_split(
         raise ValueError(f"Unknown clustering method: {method}")
 
     labels = clusterer.fit_predict(embeddings)
-
-    # Group indices by cluster
-    cluster_to_indices = defaultdict(list)
+    cluster_to_indices: dict[int, list[int]] = defaultdict(list)
     for idx, label in enumerate(labels):
-        cluster_to_indices[label].append(idx)
+        cluster_to_indices[int(label)].append(idx)
 
-    # Sort clusters by size (larger clusters assigned first for better ratio)
-    clusters_by_size = sorted(
-        cluster_to_indices.items(),
-        key=lambda x: len(x[1]),
-        reverse=True
-    )
-
-    # Greedily assign clusters to train until we hit target ratio
-    n_samples = len(embeddings)
     target_train = resolve_n_train(n_samples, train_size)
+    target_test = n_samples - target_train
 
-    train_indices = []
-    test_indices = []
+    if strategy == "size":
+        train, test = _assign_by_size(cluster_to_indices, target_train)
+    elif strategy == "centroid":
+        train, test = _assign_by_centroid(embeddings, cluster_to_indices, target_train)
+    elif strategy == "closest":
+        train, test = _assign_closest(embeddings, cluster_to_indices, target_test)
+    else:  # subset_sum
+        train, test = _assign_subset_sum(cluster_to_indices, y, target_test, n_samples)
 
-    for cluster_id, indices in clusters_by_size:
-        # DBSCAN noise points (label=-1) go to test set
-        if cluster_id == -1:
-            test_indices.extend(indices)
-            continue
-
-        if len(train_indices) + len(indices) <= target_train:
-            train_indices.extend(indices)
-        else:
-            test_indices.extend(indices)
-
-    return as_index_array(train_indices), as_index_array(test_indices)
+    return as_index_array(train), as_index_array(test)
 
 
 def centroid_adversarial_split(
@@ -116,6 +310,8 @@ def centroid_adversarial_split(
     Combines centroid-distance ranking with cluster-based splitting to
     maximize train-test dissimilarity while keeping similar samples together.
 
+    Thin wrapper over ``cluster_split(strategy="centroid")``.
+
     Args:
         embeddings: array-like of shape (n_samples, embedding_dim)
         train_size: fraction in (0, 1) or absolute count for the training set
@@ -127,39 +323,228 @@ def centroid_adversarial_split(
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
     """
-    embeddings = validate_split_inputs(embeddings, train_size)
-
-    labels, cluster_to_indices, cluster_centers = cluster_embeddings(
-        embeddings, n_clusters, "kmeans", random_state, **cluster_kwargs
+    return cluster_split(
+        embeddings,
+        train_size=train_size,
+        method="kmeans",
+        n_clusters=n_clusters,
+        random_state=random_state,
+        strategy="centroid",
+        **cluster_kwargs,
     )
 
-    # Compute global centroid
-    global_centroid = compute_centroid(embeddings)
 
-    # Rank clusters by distance from global centroid
-    cluster_distances = []
-    for i, center in enumerate(cluster_centers):
-        dist = np.linalg.norm(center - global_centroid)
-        cluster_distances.append((i, dist))
+def cluster_kfold(
+    embeddings: ArrayLike,
+    y: ArrayLike,
+    n_folds: int = 5,
+    method: str = "kmeans",
+    n_clusters: int | None = None,
+    random_state: int = 42,
+    **cluster_kwargs: Any,
+) -> np.ndarray:
+    """Partition data into challenging, label-balanced cross-validation folds.
 
-    # Sort by distance (closest first -> train, furthest -> test)
-    cluster_distances.sort(key=lambda x: x[1])
+    Clusters the embeddings, then assigns whole clusters to ``n_folds`` folds so
+    that each fold is lexically coherent -- similar samples share a fold, making
+    every fold differ from the data trained on for it -- while its label
+    distribution stays close to the global one. This yields a "challenging" CV:
+    each held-out fold is a cluster-based blind spot rather than a random sample.
 
-    # Assign clusters to train/test based on distance ranking
+    The result is a per-sample fold id, usable directly with
+    :class:`sklearn.model_selection.PredefinedSplit`::
+
+        from sklearn.model_selection import PredefinedSplit, cross_validate
+        folds = cluster_kfold(embeddings, y, n_folds=5)
+        cross_validate(model, X, y, cv=PredefinedSplit(folds))
+
+    Args:
+        embeddings: array-like of shape (n_samples, embedding_dim)
+        y: class labels of shape (n_samples,); used to balance folds by label
+        n_folds: number of cross-validation folds (default 5)
+        method: clustering algorithm, 'kmeans' or 'dbscan'
+        n_clusters: number of clusters (kmeans only). Defaults to
+            ``max(10, n_folds * 3)`` -- comfortably above ``n_folds`` so every
+            fold can receive whole clusters.
+        random_state: for reproducibility
+        **cluster_kwargs: passed to the clustering algorithm
+
+    Returns:
+        fold_ids: integer ndarray of shape (n_samples,), values in
+        ``[0, n_folds)``. For fold ``k`` the CV test set is ``fold_ids == k``
+        and the training set is the rest.
+
+    Raises:
+        ValueError: on an unknown ``method``, an ``y``/embeddings length
+            mismatch, an out-of-range ``n_folds``, or fewer clusters than folds.
+
+    References:
+        Implements the challenging clustering-based cross-validation of Wecker,
+        Friedrich & Adel (2020), "ClusterDataSplit: Exploring Challenging
+        Clustering-Based Data Splits for Model Performance Evaluation," Eval4NLP
+        @ COLING -- folds that are lexically distinct from train while preserving
+        label balance. https://aclanthology.org/2020.eval4nlp-1.15
+    """
+    embeddings = validate_split_inputs(embeddings, 0.5)  # 0.5: unused placeholder
+    y = np.asarray(y)
     n_samples = len(embeddings)
-    target_train = resolve_n_train(n_samples, train_size)
 
-    train_indices = []
-    test_indices = []
+    if len(y) != n_samples:
+        raise ValueError(f"y has length {len(y)} but embeddings has {n_samples} rows")
+    if not 2 <= n_folds <= n_samples:
+        raise ValueError(f"n_folds must be in [2, {n_samples}], got {n_folds}")
 
-    for cluster_id, _ in cluster_distances:
-        indices = cluster_to_indices[cluster_id]
-        if len(train_indices) + len(indices) <= target_train:
-            train_indices.extend(indices)
-        else:
-            test_indices.extend(indices)
+    if n_clusters is None:
+        n_clusters = max(10, n_folds * 3)
+    n_clusters = min(n_clusters, n_samples)
+    if n_clusters < n_folds:
+        raise ValueError(
+            f"need at least n_folds={n_folds} clusters, got n_clusters={n_clusters}"
+        )
 
-    return as_index_array(train_indices), as_index_array(test_indices)
+    if method == "kmeans":
+        clusterer = KMeans(
+            n_clusters=n_clusters,
+            random_state=random_state,
+            n_init="auto",
+            **cluster_kwargs,
+        )
+    elif method == "dbscan":
+        clusterer = DBSCAN(**cluster_kwargs)
+    else:
+        raise ValueError(f"Unknown clustering method: {method}")
+
+    labels = clusterer.fit_predict(embeddings)
+    cluster_to_indices: dict[int, list[int]] = defaultdict(list)
+    for idx, label in enumerate(labels):
+        cluster_to_indices[int(label)].append(idx)
+
+    classes = np.unique(y)
+    class_idx = {c: k for k, c in enumerate(classes)}
+
+    # Per-cluster class-count vectors.
+    clusters = []
+    for idxs in cluster_to_indices.values():
+        vec = np.zeros(len(classes))
+        labs, counts = np.unique(y[idxs], return_counts=True)
+        for c, cnt in zip(labs, counts):
+            vec[class_idx[c]] = cnt
+        clusters.append((idxs, vec))
+
+    # Target per-fold class counts: the global label distribution, split n_folds ways.
+    global_counts = np.array([np.sum(y == c) for c in classes], dtype=float)
+    target = global_counts / n_folds
+
+    # Place the largest clusters first into the fold that overshoots the per-fold
+    # target least (so under-filled and empty folds are preferred, keeping labels
+    # balanced); ties go to the currently-smallest fold to balance fold sizes.
+    fold_counts = [np.zeros(len(classes)) for _ in range(n_folds)]
+    fold_ids = np.empty(n_samples, dtype=np.intp)
+    clusters.sort(key=lambda t: len(t[0]), reverse=True)
+    for idxs, vec in clusters:
+        k = min(
+            range(n_folds),
+            key=lambda f: (
+                float(np.maximum(fold_counts[f] + vec - target, 0).sum()),
+                float(fold_counts[f].sum()),
+            ),
+        )
+        fold_counts[k] = fold_counts[k] + vec
+        fold_ids[idxs] = k
+
+    return fold_ids
+
+
+def minority_split(
+    embeddings: ArrayLike,
+    y: ArrayLike,
+    n_clusters: int = 10,
+    method: str = "kmeans",
+    random_state: int = 42,
+    **cluster_kwargs: Any,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Bias-amplified split via per-cluster minority labels.
+
+    Clusters the embeddings, then for each cluster routes instances whose label
+    is the cluster's *majority* label to train (the "biased" majority a
+    shortcut-learning model would exploit) and instances with any *minority*
+    label to test (the "anti-biased" examples that defy the local pattern),
+    yielding a hard, bias-amplified evaluation set.
+
+    Unlike the size-driven splitters, the train/test sizes are determined by the
+    data's bias structure (test = the minority-label instances), so this function
+    takes no ``train_size``. It inspects per-cluster label counts only; it never
+    references global class frequencies.
+
+    Args:
+        embeddings: array-like of shape (n_samples, embedding_dim)
+        y: class labels of shape (n_samples,)
+        n_clusters: number of clusters (kmeans only)
+        method: clustering algorithm, 'kmeans' or 'dbscan'
+        random_state: for reproducibility
+        **cluster_kwargs: passed to the clustering algorithm
+
+    Returns:
+        train_indices: majority-label ("biased") instances, pooled over clusters
+        test_indices: minority-label ("anti-biased") instances, pooled over clusters
+
+    Raises:
+        ValueError: on an unknown ``method``, a ``y``/embeddings length mismatch,
+            or if no minority examples exist (every cluster is label-pure -- try
+            a different ``n_clusters`` or embeddings).
+
+    References:
+        Implements the "minority examples" notion of bias from Reif & Schwartz
+        (2023), "Fighting Bias with Bias: Promoting Model Robustness by Amplifying
+        Dataset Biases," Findings of ACL, pp. 13169-13189
+        (https://aclanthology.org/2023.findings-acl.833): cluster the data, treat
+        each cluster's majority label as biased (train) and its minority labels as
+        anti-biased (test). Their other two notions -- dataset cartography
+        (training dynamics) and partial-input models -- are model-in-the-loop /
+        task-specific and out of scope for a static splitter.
+    """
+    embeddings = validate_split_inputs(embeddings, 0.5)  # 0.5: unused placeholder
+    y = np.asarray(y)
+    n_samples = len(embeddings)
+    if len(y) != n_samples:
+        raise ValueError(f"y has length {len(y)} but embeddings has {n_samples} rows")
+
+    if method == "kmeans":
+        clusterer = KMeans(
+            n_clusters=n_clusters,
+            random_state=random_state,
+            n_init="auto",
+            **cluster_kwargs,
+        )
+    elif method == "dbscan":
+        clusterer = DBSCAN(**cluster_kwargs)
+    else:
+        raise ValueError(f"Unknown clustering method: {method}")
+
+    labels = clusterer.fit_predict(embeddings)
+    cluster_to_indices: dict[int, list[int]] = defaultdict(list)
+    for idx, label in enumerate(labels):
+        cluster_to_indices[int(label)].append(idx)
+
+    train: list[int] = []
+    test: list[int] = []
+    for idxs in cluster_to_indices.values():
+        idx_arr = np.asarray(idxs)
+        cls_labels = y[idx_arr]
+        vals, counts = np.unique(cls_labels, return_counts=True)
+        majority = vals[np.argmax(counts)]  # ties -> lowest label (deterministic)
+        is_majority = cls_labels == majority
+        train.extend(idx_arr[is_majority].tolist())
+        test.extend(idx_arr[~is_majority].tolist())
+
+    if not test:
+        raise ValueError(
+            "no minority examples found (every cluster is label-pure); "
+            "try a different n_clusters or embeddings"
+        )
+
+    return as_index_array(sorted(train)), as_index_array(sorted(test))
 
 
 def distance_adversarial_split(
@@ -513,8 +898,7 @@ def wasserstein_adversarial_split(
     Treats each embedding row as a 1-D distribution and selects, as the test
     set, the ``n_test`` points nearest (in 1-D Wasserstein / earth-mover
     distance) to a random anchor — yielding a tight, hard-to-generalize-to test
-    neighborhood. Adapted from Søgaard et al., "We Need to Talk About Random
-    Splits" (EACL 2021), https://aclanthology.org/2021.eacl-main.156 .
+    neighborhood.
 
     Args:
         embeddings: array-like of shape (n_samples, embedding_dim)
@@ -525,6 +909,12 @@ def wasserstein_adversarial_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    References:
+        Adapted from the adversarial split of Søgaard, Ebert, Bastings &
+        Filippova (2021), "We Need to Talk About Random Splits," EACL, which
+        constructs hard splits by (approximately) maximizing the Wasserstein
+        distance between train and test. https://aclanthology.org/2021.eacl-main.156
     """
     from scipy.stats import wasserstein_distance
     from sklearn.neighbors import NearestNeighbors
@@ -553,6 +943,76 @@ def wasserstein_adversarial_split(
     test_set = {int(i) for i in test_indices}
     train_indices = [i for i in range(n_samples) if i not in test_set]
     return as_index_array(train_indices), as_index_array(test_indices)
+
+
+def mmd_maximized_split(
+    embeddings: ArrayLike,
+    train_size: float | int = 0.7,
+    n_iterations: int = 500,
+    kernel: str = "rbf",
+    gamma: float | None = None,
+    random_state: int = 42,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Maximize Maximum Mean Discrepancy (MMD) between train and test.
+
+    The adversarial dual of :func:`splytters.mmd_minimized_split`: instead of
+    matching the two distributions, it pushes them as far apart as possible in
+    kernel/MMD terms, yielding a hard, domain-shifted held-out set. Motivated by
+    model selection under domain shift -- a maximally-shifted validation set
+    tends to select more robust hyperparameters.
+
+    Args:
+        embeddings: array-like of shape (n_samples, embedding_dim)
+        train_size: fraction in (0, 1) or absolute count for the training set
+        n_iterations: number of optimization iterations
+        kernel: kernel type ('rbf' or 'linear')
+        gamma: RBF kernel parameter (default: 1/n_features)
+        random_state: for reproducibility
+
+    Returns:
+        train_indices: ndarray of indices for training set
+        test_indices: ndarray of indices for test set
+
+    References:
+        Implements the *objective* of Napoli & White (2025), "Clustering-Based
+        Validation Splits for Model Selection under Domain Shift," TMLR
+        (https://openreview.net/forum?id=Q692C0WtiD): the train/validation split
+        should maximize the MMD between the two sets. NOTE: this captures that
+        objective via swap optimization (like ``mmd_minimized_split``); it does
+        not implement their full method -- a constrained kernel k-means (max-MMD
+        is shown equivalent to kernel k-means with k=2) solved by linear
+        programming to preserve class/group balance, with convergence guarantees
+        and Nyström scaling. For class-balanced clustering splits, see
+        ``cluster_split(strategy="subset_sum")`` and :func:`cluster_kfold`.
+    """
+    embeddings = validate_split_inputs(embeddings, train_size)
+    n_dims = embeddings.shape[1]
+
+    _gamma = gamma if gamma is not None else 1.0 / n_dims
+
+    def _rbf_kernel(X: np.ndarray, Y: np.ndarray) -> np.ndarray:
+        return np.exp(-_gamma * cdist(X, Y, metric="sqeuclidean"))
+
+    def _linear_kernel(X: np.ndarray, Y: np.ndarray) -> np.ndarray:
+        return X @ Y.T
+
+    kernel_fn = _rbf_kernel if kernel == "rbf" else _linear_kernel
+
+    def score_fn(X: np.ndarray, train: list[int], test: list[int]) -> float:
+        train_data, test_data = X[train], X[test]
+        K_tt = kernel_fn(train_data, train_data)
+        K_ss = kernel_fn(test_data, test_data)
+        K_ts = kernel_fn(train_data, test_data)
+        m, n = len(train_data), len(test_data)
+        return (K_tt.sum() / (m * m) +
+                K_ss.sum() / (n * n) -
+                2 * K_ts.sum() / (m * n))
+
+    # minimize=False -> push the two distributions apart (adversarial dual).
+    return optimized_split(
+        embeddings, train_size, n_iterations, score_fn, random_state, minimize=False
+    )
 
 
 def get_cluster_info(

--- a/splytters/adversarial.py
+++ b/splytters/adversarial.py
@@ -140,7 +140,7 @@ def _assign_subset_sum(
     for cid, idxs in cluster_to_indices.items():
         v = np.zeros(len(classes))
         labels_here, counts = np.unique(y[idxs], return_counts=True)
-        for c, cnt in zip(labels_here, counts):
+        for c, cnt in zip(labels_here, counts, strict=True):
             v[class_idx[c]] = cnt
         vecs[cid] = v
 
@@ -427,7 +427,7 @@ def cluster_kfold(
     for idxs in cluster_to_indices.values():
         vec = np.zeros(len(classes))
         labs, counts = np.unique(y[idxs], return_counts=True)
-        for c, cnt in zip(labs, counts):
+        for c, cnt in zip(labs, counts, strict=True):
             vec[class_idx[c]] = cnt
         clusters.append((idxs, vec))
 

--- a/splytters/balanced.py
+++ b/splytters/balanced.py
@@ -259,6 +259,13 @@ def mmd_minimized_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    References:
+        The adversarial dual -- *maximizing* train/validation MMD for robust
+        model selection under domain shift -- is studied by Napoli & White
+        (2025), "Clustering-Based Validation Splits for Model Selection under
+        Domain Shift," TMLR (https://openreview.net/forum?id=Q692C0WtiD). See
+        :func:`splytters.mmd_maximized_split`.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_dims = embeddings.shape[1]

--- a/splytters/sorters/__init__.py
+++ b/splytters/sorters/__init__.py
@@ -49,6 +49,7 @@ _LAZY: dict[str, tuple[str, str]] = {
     "image_compression_ratio": ("image_sorters", "compression_ratio"),
     "frequency_content": ("image_sorters", "frequency_content"),
     # Audio sorters (deps: [audio])
+    "duration": ("audio_sorters", "duration"),
     "mean_amplitude": ("audio_sorters", "mean_amplitude"),
     "rms_energy": ("audio_sorters", "rms_energy"),
     "dynamic_range": ("audio_sorters", "dynamic_range"),

--- a/splytters/sorters/audio_sorters.py
+++ b/splytters/sorters/audio_sorters.py
@@ -48,6 +48,50 @@ def _load_audio(audio: AudioInput, sr: int = 22050) -> tuple[np.ndarray, int]:
 
 
 # =============================================================================
+# Duration / Length
+# =============================================================================
+
+def duration(
+    audios: list[AudioInput], sr: int = 22050, low_first: bool = True
+) -> list[tuple[int, float]]:
+    """
+    Sort audio by total duration in seconds.
+
+    Useful for adversarial / curriculum splits: train on short utterances,
+    test on long ones (or vice versa). Pair with
+    :func:`splytters.sorted_stratified_split` for a length-based curriculum.
+
+    Args:
+        audios: list of file paths or (samples, sr) tuples
+        sr: sample rate for loading files (default 22050)
+        low_first: if True, shortest audio first; if False, longest first
+
+    Returns:
+        List of (index, seconds) tuples sorted by duration.
+
+    References:
+        Liu, Spence & Prud'hommeaux (2023), "Investigating data partitioning
+        strategies for crosslinguistic low-resource ASR evaluation," EACL,
+        pp. 123-131. https://aclanthology.org/2023.eacl-main.10 . They build
+        heuristic test sets from per-utterance features -- utterance duration,
+        average intensity, average pitch, transcript token count and perplexity
+        -- and find utterance duration and intensity to be the most predictive
+        factors of word-error-rate variability across data splits. Caveat: in
+        their very low-resource setting, heuristic and adversarial splits behaved
+        much like random splits, which were the more reliable choice under data
+        sparsity -- so prefer random/averaged splits when data is scarce.
+    """
+    scores = []
+    for i, audio in enumerate(audios):
+        y, sample_rate = _load_audio(audio, sr)
+        seconds = len(y) / sample_rate if sample_rate else 0.0
+        scores.append((i, seconds))
+
+    scores.sort(key=lambda p: p[1], reverse=not low_first)
+    return [(idx, float(value)) for idx, value in scores]
+
+
+# =============================================================================
 # Loudness / Energy
 # =============================================================================
 
@@ -67,6 +111,11 @@ def mean_amplitude(
 
     Returns:
         List of (index, amplitude) tuples sorted by mean amplitude.
+
+    References:
+        A loudness/intensity feature; see :func:`duration` for the
+        Liu, Spence & Prud'hommeaux (2023) ASR data-partitioning study, which
+        uses average intensity as a heuristic split feature.
     """
     scores = []
     for i, audio in enumerate(audios):
@@ -97,6 +146,11 @@ def rms_energy(
 
     Returns:
         List of (index, rms) tuples sorted by RMS energy.
+
+    References:
+        RMS energy is an "average intensity" measure; see :func:`duration` for
+        the Liu, Spence & Prud'hommeaux (2023) ASR data-partitioning study, which
+        found intensity among the most predictive features of WER variability.
     """
     scores = []
     for i, audio in enumerate(audios):
@@ -357,6 +411,11 @@ def fundamental_frequency(
     Returns:
         List of (index, f0_hz) tuples sorted by fundamental frequency.
         Audio with no detectable pitch receives f0 of 0.
+
+    References:
+        Pitch is one of the per-utterance heuristic split features in
+        Liu, Spence & Prud'hommeaux (2023); see :func:`duration` for the full
+        citation.
     """
     scores = []
     for i, audio in enumerate(audios):

--- a/splytters/sorters/text_sorters.py
+++ b/splytters/sorters/text_sorters.py
@@ -35,6 +35,23 @@ def character_length(texts: list[str], low_first: bool = True) -> list[tuple[int
 
     Returns:
         List of (index, character_count) tuples sorted by length.
+
+    References:
+        Splitting by length to test generalization (put long texts in test):
+          - Søgaard, Ebert, Bastings & Filippova (2021), "We Need to Talk
+            About Random Splits," EACL. Heuristic splits via a sentence-length
+            threshold. https://aclanthology.org/2021.eacl-main.156
+          - Varis & Bojar (2021), "Sequence Length is a Domain: Length-based
+            Overfitting in Transformer Models," EMNLP.
+            https://aclanthology.org/2021.emnlp-main.650
+          - Lake & Baroni (2018), "Generalization without Systematicity," ICML,
+            introduced the SCAN length split (train short, test long) -- a
+            canonical length-generalization test (on output sequence length,
+            synthetic data). https://arxiv.org/abs/1711.00350
+          - Søgaard et al. trace the idea of testing generalization to longer
+            sequences back to Siegelmann & Sontag (1992), "On the Computational
+            Power of Neural Nets," COLT, pp. 440-449.
+            https://doi.org/10.1145/130385.130432
     """
     scores = [(i, len(text)) for i, text in enumerate(texts)]
     scores.sort(key=lambda p: p[1], reverse=not low_first)
@@ -56,6 +73,12 @@ def tokens_length(
 
     Returns:
         List of (index, token_count) tuples sorted by token count.
+
+    References:
+        A token-count variant of length-based splitting; see ``character_length``
+        for the motivation and references (Søgaard et al. 2021, EACL; Varis &
+        Bojar 2021, EMNLP; Lake & Baroni 2018, ICML; Siegelmann & Sontag 1992,
+        COLT).
     """
     scores = [(i, len(tokenizer(text))) for i, text in enumerate(texts)]
     scores.sort(key=lambda p: p[1], reverse=not low_first)
@@ -180,27 +203,58 @@ def perplexity_score(
     model: GPT2LMHeadModel | None = None,
     tokenizer: GPT2TokenizerFast | None = None,
     low_first: bool = True,
+    scoring: str = "perplexity",
 ) -> list[tuple[int, float]]:
     """
-    Sort texts by language model perplexity.
+    Sort texts by how typical a language model finds them.
 
-    Perplexity measures how "surprised" a language model is by the text.
-    Lower perplexity indicates more typical/predictable text, higher
-    perplexity indicates unusual or difficult text.
+    A causal LM is run over each text to measure how "surprised" it is. Two
+    scoring modes are offered (see ``scoring``); both rank the same way — typical
+    text is ordered before unusual text — but they put different things in the
+    difficult tail, so the returned score values differ.
 
-    Useful for adversarial splits: train on typical text, test on unusual text.
+    Useful for adversarial / curriculum splits: train on typical text, test on
+    unusual text. Pair with :func:`splytters.sorted_stratified_split` to build
+    "Likelihood Splits" (train on the high-likelihood head, test on the tail).
 
     Args:
         texts: list of strings to score
         model: HuggingFace causal LM (defaults to GPT-2 if None)
         tokenizer: HuggingFace tokenizer (defaults to GPT-2 if None)
-        low_first: if True, typical/predictable texts first;
-                   if False, unusual/surprising texts first
+        low_first: if True, typical/predictable texts first; if False,
+            unusual/surprising texts first. The ordering is by *typicality*, so
+            this holds for both scoring modes despite their opposite raw-value
+            directions.
+        scoring: how to score each text.
+            - ``"perplexity"`` (default): ``exp`` of the mean per-token negative
+              log-likelihood. Length-normalized; *lower* is more typical.
+            - ``"log_likelihood"``: total (un-normalized) log-likelihood summed
+              over the predicted tokens; *higher* is more typical. This is the
+              score used by Likelihood Splits (Godbole & Jia, 2023).
 
     Returns:
-        List of (index, perplexity) tuples sorted by perplexity.
-        Texts too short to score receive perplexity of infinity.
+        List of ``(index, score)`` tuples in the chosen metric's natural units,
+        ordered by typicality per ``low_first``. Texts too short to score receive
+        the most-difficult sentinel (``+inf`` perplexity / ``-inf``
+        log-likelihood), so they always land in the tail.
+
+    Raises:
+        ValueError: if ``scoring`` is not ``"perplexity"`` or ``"log_likelihood"``.
+
+    References:
+        Godbole & Jia (2023), "Benchmarking Long-tail Generalization with
+        Likelihood Splits," Findings of the ACL: EACL, pp. 963-983 —
+        https://aclanthology.org/2023.findings-eacl.71 . They split datasets by
+        LM likelihood (head -> train, tail -> test). Note they deliberately use
+        *total log-likelihood* rather than perplexity: perplexity normalizes for
+        length and over-corrects toward short examples in the tail (their fn. 3).
+        Use ``scoring="log_likelihood"`` to reproduce their choice.
     """
+    if scoring not in ("perplexity", "log_likelihood"):
+        raise ValueError(
+            f"scoring must be 'perplexity' or 'log_likelihood', got {scoring!r}"
+        )
+
     import torch
     from transformers import GPT2LMHeadModel, GPT2TokenizerFast
 
@@ -210,24 +264,38 @@ def perplexity_score(
         model.eval()
 
     device = next(model.parameters()).device
-    scores = []
 
+    # Texts too short to score sort into the difficult tail regardless of mode:
+    # maximal perplexity (+inf) or minimal log-likelihood (-inf).
+    unscorable = float("inf") if scoring == "perplexity" else float("-inf")
+
+    scores = []
     with torch.no_grad():
         for i, text in enumerate(texts):
             encodings = tokenizer(text, return_tensors="pt").to(device)
             input_ids = encodings.input_ids
 
             if input_ids.size(1) < 2:
-                # Too short to compute perplexity
-                scores.append((i, float("inf")))
+                # Too short to compute a per-token loss
+                scores.append((i, unscorable))
                 continue
 
             outputs = model(input_ids, labels=input_ids)
-            loss = outputs.loss.item()
-            perplexity = torch.exp(torch.tensor(loss)).item()
-            scores.append((i, perplexity))
+            loss = outputs.loss.item()  # mean per-token negative log-likelihood
+            if scoring == "perplexity":
+                score = torch.exp(torch.tensor(loss)).item()
+            else:
+                n_tokens = input_ids.size(1) - 1  # number of predicted tokens
+                score = -loss * n_tokens  # total log-likelihood
+            scores.append((i, score))
 
-    scores.sort(key=lambda p: p[1], reverse=not low_first)
+    # Sort by difficulty (higher == more atypical/tail) so that low_first means
+    # typical-first in both modes: high perplexity == low log-likelihood == hard.
+    def difficulty(pair: tuple[int, float]) -> float:
+        score = pair[1]
+        return score if scoring == "perplexity" else -score
+
+    scores.sort(key=difficulty, reverse=not low_first)
     return scores
 
 

--- a/tests/test_audio_sorters.py
+++ b/tests/test_audio_sorters.py
@@ -2,12 +2,15 @@
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from splytters.sorters.audio_sorters import (
     beat_strength,
     # Quality
     compression_ratio,
+    # Duration / Length
+    duration,
     dynamic_range,
     fundamental_frequency,
     harmonic_ratio,
@@ -39,6 +42,39 @@ def get_audio_path(name):
 def get_sorted_names(results, audios):
     """Extract audio names from sorted results."""
     return [audios[idx].stem for idx, *_ in results]
+
+
+class TestDuration:
+    """Tests for duration function (uses synthetic arrays, no librosa needed)."""
+
+    def test_orders_short_before_long(self):
+        sr = 22050
+        audios = [
+            (np.zeros(sr * 3), sr),  # 3s
+            (np.zeros(sr * 1), sr),  # 1s
+            (np.zeros(sr * 2), sr),  # 2s
+        ]
+        order = [idx for idx, _ in duration(audios, low_first=True)]
+        assert order == [1, 2, 0]
+
+    def test_orders_long_before_short(self):
+        sr = 22050
+        audios = [(np.zeros(sr), sr), (np.zeros(sr * 2), sr)]
+        order = [idx for idx, _ in duration(audios, low_first=False)]
+        assert order == [1, 0]
+
+    def test_reports_seconds(self):
+        sr = 16000
+        results = duration([(np.zeros(sr * 2), sr)])
+        assert results[0][1] == pytest.approx(2.0)
+
+    def test_returns_correct_structure(self):
+        sr = 22050
+        results = duration([(np.zeros(sr), sr), (np.zeros(sr * 2), sr)])
+        assert len(results) == 2
+        for idx, value in results:
+            assert isinstance(idx, int)
+            assert isinstance(value, float)
 
 
 class TestMeanAmplitude:

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -5,11 +5,14 @@ import pytest
 
 from splytters.adversarial import (
     centroid_adversarial_split,
+    cluster_kfold,
     cluster_split,
     density_adversarial_split,
     distance_adversarial_split,
     get_cluster_info,
     min_cut_split,
+    minority_split,
+    mmd_maximized_split,
     normalized_cut_split,
     outlier_adversarial_split,
     wasserstein_adversarial_split,
@@ -205,6 +208,190 @@ class TestClusterSplit:
     def test_invalid_method(self, embeddings_small):
         with pytest.raises(ValueError, match="Unknown clustering method"):
             cluster_split(embeddings_small, method="invalid")
+
+
+class TestClusterSplitStrategies:
+    """The strategy= assignment policies on cluster_split."""
+
+    @pytest.fixture
+    def labels(self):
+        # Two classes, evenly interleaved across the 100 points.
+        return np.array([0, 1] * 50)
+
+    def test_unknown_strategy_raises(self, embeddings_2d):
+        with pytest.raises(ValueError, match="Unknown strategy"):
+            cluster_split(embeddings_2d, strategy="bogus")
+
+    def test_centroid_strategy_matches_wrapper(self, embeddings_2d):
+        """strategy='centroid' must equal the centroid_adversarial_split wrapper."""
+        a_tr, a_te = cluster_split(embeddings_2d, n_clusters=5, strategy="centroid")
+        b_tr, b_te = centroid_adversarial_split(embeddings_2d, n_clusters=5)
+        assert np.array_equal(a_tr, b_tr)
+        assert np.array_equal(a_te, b_te)
+
+    def test_closest_strategy_valid(self, embeddings_2d):
+        train, test = cluster_split(embeddings_2d, n_clusters=8, strategy="closest")
+        assert_valid_split(train, test, len(embeddings_2d), ratio_tol=0.25)
+
+    def test_subset_sum_requires_y(self, embeddings_2d):
+        with pytest.raises(ValueError, match="requires class labels"):
+            cluster_split(embeddings_2d, strategy="subset_sum")
+
+    def test_subset_sum_y_length_mismatch(self, embeddings_2d):
+        with pytest.raises(ValueError, match="length"):
+            cluster_split(
+                embeddings_2d, strategy="subset_sum", y=np.array([0, 1, 0])
+            )
+
+    def test_subset_sum_valid_and_class_balanced(self, embeddings_2d, labels):
+        train, test = cluster_split(
+            embeddings_2d, n_clusters=8, strategy="subset_sum", y=labels
+        )
+        assert_valid_split(train, test, len(embeddings_2d), ratio_tol=0.4)
+        # Test-set class proportions should track the global proportions.
+        global_p = labels.mean()
+        test_p = labels[test].mean()
+        assert abs(test_p - global_p) < 0.2
+
+
+class TestClusterKFold:
+    """Challenging clustering-based cross-validation folds."""
+
+    @pytest.fixture
+    def labels(self):
+        return np.array([0, 1] * 50)
+
+    def test_returns_valid_fold_ids(self, embeddings_2d, labels):
+        folds = cluster_kfold(embeddings_2d, labels, n_folds=5)
+        assert folds.shape == (len(embeddings_2d),)
+        assert set(folds.tolist()) <= set(range(5))
+
+    def test_all_folds_nonempty(self, embeddings_2d, labels):
+        folds = cluster_kfold(embeddings_2d, labels, n_folds=5)
+        assert set(folds.tolist()) == set(range(5))
+
+    def test_folds_partition_via_predefined_split(self, embeddings_2d, labels):
+        from sklearn.model_selection import PredefinedSplit
+
+        folds = cluster_kfold(embeddings_2d, labels, n_folds=5)
+        ps = PredefinedSplit(folds)
+        assert ps.get_n_splits() == 5
+        seen: set[int] = set()
+        for _, test_idx in ps.split():
+            assert not (seen & set(test_idx.tolist())), "test folds overlap"
+            seen |= set(test_idx.tolist())
+        assert seen == set(range(len(embeddings_2d))), "folds don't cover all samples"
+
+    def test_folds_are_label_balanced(self, embeddings_2d, labels):
+        folds = cluster_kfold(embeddings_2d, labels, n_folds=5)
+        global_p = labels.mean()
+        for k in range(5):
+            fold_p = labels[folds == k].mean()
+            assert abs(fold_p - global_p) < 0.2
+
+    def test_deterministic(self, embeddings_2d, labels):
+        a = cluster_kfold(embeddings_2d, labels, n_folds=4, random_state=1)
+        b = cluster_kfold(embeddings_2d, labels, n_folds=4, random_state=1)
+        assert np.array_equal(a, b)
+
+    def test_y_length_mismatch_raises(self, embeddings_2d):
+        with pytest.raises(ValueError, match="length"):
+            cluster_kfold(embeddings_2d, np.array([0, 1, 0]), n_folds=3)
+
+    def test_bad_n_folds_raises(self, embeddings_2d, labels):
+        with pytest.raises(ValueError, match="n_folds"):
+            cluster_kfold(embeddings_2d, labels, n_folds=1)
+
+    def test_too_few_clusters_raises(self, embeddings_2d, labels):
+        with pytest.raises(ValueError, match="at least"):
+            cluster_kfold(embeddings_2d, labels, n_folds=5, n_clusters=3)
+
+    def test_unknown_method_raises(self, embeddings_2d, labels):
+        with pytest.raises(ValueError, match="Unknown clustering method"):
+            cluster_kfold(embeddings_2d, labels, method="nope")
+
+
+class TestMinoritySplit:
+    """Bias-amplified split via per-cluster minority labels (Reif & Schwartz, 2023)."""
+
+    @pytest.fixture
+    def biased_data(self):
+        """Two well-separated blobs, each dominated by one label with a few
+        minority-label instances planted in."""
+        rng = np.random.RandomState(0)
+        a = rng.randn(20, 2) * 0.2 + np.array([5, 5])
+        ya = np.array([0] * 18 + [1] * 2)  # blob A: majority 0, minority {18,19}
+        b = rng.randn(20, 2) * 0.2 + np.array([-5, -5])
+        yb = np.array([1] * 18 + [0] * 2)  # blob B: majority 1, minority {38,39}
+        X = np.vstack([a, b])
+        y = np.concatenate([ya, yb])
+        return X, y
+
+    def test_routes_cluster_minority_labels_to_test(self, biased_data):
+        X, y = biased_data
+        train, test = minority_split(X, y, n_clusters=2, random_state=0)
+        assert set(test.tolist()) == {18, 19, 38, 39}
+        # A full partition of all samples (no overlap, full cover).
+        assert set(train.tolist()) | set(test.tolist()) == set(range(40))
+        assert not (set(train.tolist()) & set(test.tolist()))
+
+    def test_deterministic(self, biased_data):
+        X, y = biased_data
+        a = minority_split(X, y, n_clusters=2, random_state=0)
+        b = minority_split(X, y, n_clusters=2, random_state=0)
+        assert _splits_equal(a, b)
+
+    def test_label_pure_clusters_raise(self):
+        rng = np.random.RandomState(1)
+        X = np.vstack([rng.randn(20, 2) + [5, 5], rng.randn(20, 2) + [-5, -5]])
+        y = np.zeros(40, dtype=int)  # single label everywhere -> no minority
+        with pytest.raises(ValueError, match="no minority examples"):
+            minority_split(X, y, n_clusters=2)
+
+    def test_y_length_mismatch_raises(self, embeddings_2d):
+        with pytest.raises(ValueError, match="length"):
+            minority_split(embeddings_2d, np.array([0, 1, 0]))
+
+    def test_unknown_method_raises(self, embeddings_2d):
+        y = np.array([0, 1] * 50)
+        with pytest.raises(ValueError, match="Unknown clustering method"):
+            minority_split(embeddings_2d, y, method="nope")
+
+
+class TestMMDMaximizedSplit:
+    """Adversarial dual of mmd_minimized_split (Napoli & White, 2025)."""
+
+    @staticmethod
+    def _mmd(emb, train, test):
+        gamma = 1.0 / emb.shape[1]
+        from scipy.spatial.distance import cdist
+
+        def k(a, b):
+            return np.exp(-gamma * cdist(a, b, "sqeuclidean"))
+
+        T, S = emb[train], emb[test]
+        m, n = len(T), len(S)
+        return (
+            k(T, T).sum() / (m * m)
+            + k(S, S).sum() / (n * n)
+            - 2 * k(T, S).sum() / (m * n)
+        )
+
+    def test_valid_split(self, embeddings_2d):
+        train, test = mmd_maximized_split(embeddings_2d)
+        assert_valid_split(train, test, len(embeddings_2d))
+
+    def test_higher_mmd_than_minimized(self, embeddings_2d):
+        tr_max, te_max = mmd_maximized_split(embeddings_2d, n_iterations=500)
+        tr_min, te_min = mmd_minimized_split(embeddings_2d, n_iterations=500)
+        assert self._mmd(embeddings_2d, tr_max, te_max) > self._mmd(
+            embeddings_2d, tr_min, te_min
+        )
+
+    def test_deterministic(self, embeddings_2d):
+        a = mmd_maximized_split(embeddings_2d, random_state=3)
+        b = mmd_maximized_split(embeddings_2d, random_state=3)
+        assert _splits_equal(a, b)
 
 
 class TestCentroidAdversarialSplit:

--- a/tests/test_text_sorters.py
+++ b/tests/test_text_sorters.py
@@ -282,6 +282,36 @@ class TestPerplexityScore:
         # Normal sentence should be first
         assert indices[0] == 0
 
+    def test_invalid_scoring_raises(self, texts):
+        """An unknown scoring mode should raise ValueError (no model load)."""
+        with pytest.raises(ValueError, match="scoring must be"):
+            perplexity_score(texts, scoring="bogus")
+
+    @pytest.mark.slow
+    def test_log_likelihood_orders_typical_first(self, texts):
+        """log_likelihood mode ranks by typicality too: normal text first."""
+        result = perplexity_score(texts, low_first=True, scoring="log_likelihood")
+        indices = [idx for idx, _ in result]
+        assert indices[0] == 0
+
+    @pytest.mark.slow
+    def test_log_likelihood_normal_text_more_likely(self, texts):
+        """Normal text should have higher total log-likelihood than nonsense."""
+        result = perplexity_score(texts, scoring="log_likelihood")
+        scores = {idx: ll for idx, ll in result}
+        assert scores[0] > scores[2]
+
+    @pytest.mark.slow
+    def test_log_likelihood_short_text_gets_neg_infinity(self):
+        """Unscorable text gets -inf (tail) under log_likelihood scoring."""
+        result = perplexity_score(
+            ["a", "The cat sat on the mat."], scoring="log_likelihood"
+        )
+        scores = {idx: ll for idx, ll in result}
+        assert scores[0] == float("-inf")
+        # ...and -inf sorts to the difficult tail, not the typical head.
+        assert result[-1][0] == 0
+
 
 class TestReadabilityScore:
     """Tests for readability_score function."""


### PR DESCRIPTION
New splitting capabilities:
- cluster_split: add strategy= axis (size|centroid|subset_sum|closest); centroid_adversarial_split now delegates to strategy="centroid". subset_sum and closest implement Zufle et al. (2023); ClusterDataSplit (Wecker et al. 2020) and Napoli & White (2025) cited as the label-balanced/MMD grounding.
- cluster_kfold: challenging clustering-based, label-balanced CV folds (Wecker et al. 2020); returns fold ids for sklearn PredefinedSplit.
- mmd_maximized_split: adversarial dual of mmd_minimized_split, the max-MMD objective of Napoli & White (2025).
- minority_split: per-cluster minority-label "bias-amplified" split (Reif & Schwartz 2023, "minority examples" notion).

New / extended sorters:
- audio: duration sorter; cite Liu, Spence & Prud'hommeaux (2023) on duration/rms_energy/fundamental_frequency.
- text perplexity_score: scoring="log_likelihood" (total log-likelihood), reproducing Godbole & Jia (2023) Likelihood Splits; fixes sort direction and sentinel per mode.

Docstring references added: Sogaard et al. (2021), Varis & Bojar (2021), Lake & Baroni (2018), Siegelmann & Sontag (1992) on the length sorters; Godbole & Jia (2023) on perplexity_score.

Tests cover all new strategies, cluster_kfold, mmd_maximized_split, minority_split, the audio duration sorter, and log_likelihood scoring.