### PR TITLE
ci(coverage): measure coverage on full suite and upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,11 @@ jobs:
       - name: Install with all extras
         run: pip install -e ".[dev]"
       - name: Full suite (excluding slow model-download tests)
-        run: pytest -m "not slow" -q
+        run: pytest -m "not slow" -q --cov=splytters --cov-report=xml
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # splytters
 
 [![CI](https://github.com/gxlarson/splytters/actions/workflows/ci.yml/badge.svg)](https://github.com/gxlarson/splytters/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/gxlarson/splytters/branch/main/graph/badge.svg)](https://codecov.io/gh/gxlarson/splytters)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ all = ["splytters[text,image,audio,tabular,embedders,viz,demo,ann]"]
 dev = [
     "splytters[all,docs]",
     "pytest",
+    "pytest-cov",
     "ruff",
 ]
 
@@ -96,6 +97,17 @@ splytters = ["py.typed"]
 testpaths = ["tests"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["splytters"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Run the full (all-extras) job under pytest-cov and upload coverage.xml to Codecov. Upload runs with `if: always()` so the badge still updates when the canary job trips on upstream dependency drift. Add a [tool.coverage] config and a codecov badge to the README.