### PR TITLE
feat(metrics): integrate diversity metrics into split reporting

### DIFF
--- a/splytters/distances.py
+++ b/splytters/distances.py
@@ -3,15 +3,9 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator
 from difflib import SequenceMatcher
 
-from numpy.typing import ArrayLike
-from scipy.spatial.distance import euclidean as _dist_euclidean
-
 
 def simple_tokenizer(s: str) -> list[str]:
     return s.split()
-
-def dist_euclidean(u: ArrayLike, v: ArrayLike) -> float:
-    return _dist_euclidean(u, v)
 
 def difflib_character_similarity(s1: str, s2: str) -> float:
     return SequenceMatcher(a=s1, b=s2).ratio()
@@ -70,12 +64,3 @@ def ngram_jaccard_distance(t1: str, t2: str, n: int = 3) -> float:
     sim = ngram_jaccard_similarity(t1, t2, n)
     dist = 1 - sim
     return dist
-
-if __name__ == "__main__":
-    # simple test
-    text1 = 'my bank balance is what'
-    text2 = 'what is my bank balance'
-    s = ngram_jaccard_similarity(text1, text2)
-    print(s)
-    s = difflib_token_similarity(text1, text2)
-    print(s)

--- a/splytters/metrics.py
+++ b/splytters/metrics.py
@@ -1,34 +1,49 @@
+"""
+Diversity metrics for split comparison.
+
+These quantify the *spread* of a set of samples — how varied train or test is
+on its own — complementing the train/test *distance* metrics in
+:mod:`splytters.report`. Used to compare split strategies (e.g. random vs
+adversarial) on coverage/diversity, not just separation.
+"""
+
 from __future__ import annotations
 
 from collections.abc import Callable
-from statistics import mean
 
 import numpy as np
 
-from splytters.distances import (
-    dist_euclidean,
-    ngram_jaccard_distance,
-)
+from splytters.distances import ngram_jaccard_distance
 
-
-def simple_tokenizer(s: str) -> list[str]:
-    return s.split()
 
 def mean_dist(
     embeddings: np.ndarray,
-    distance: Callable[[np.ndarray, np.ndarray], float] = dist_euclidean,
+    distance: Callable[[np.ndarray, np.ndarray], float] | None = None,
 ) -> float:
-    """
-    computes mean distance from all samples to the centroid
+    """Mean distance from each sample to the centroid — a spread/diversity score.
 
-    this is sample variance when euclidean distance is used
+    With the default (Euclidean) distance this is the mean L2 distance of points
+    to their centroid: larger means the set is more spread out. Pass a custom
+    symmetric ``distance(u, v)`` to override; the default path is vectorized.
+
+    Args:
+        embeddings: array of shape (n_samples, n_features).
+        distance: optional callable ``d(u, v) -> float``. If ``None`` (default),
+            uses a vectorized Euclidean distance.
+
+    Returns:
+        Mean distance to the centroid (``0.0`` for an empty set).
     """
-    (n, d) = embeddings.shape
-    centroid = embeddings.mean(0)
-    distances = []
-    for i in range(n):
-        distances.append(distance(centroid, embeddings[i]))
-    return mean(distances)
+    X = np.asarray(embeddings, dtype=float)
+    if X.ndim != 2:
+        raise ValueError("embeddings must be 2-D (n_samples, n_features)")
+    if len(X) == 0:
+        return 0.0
+    centroid = X.mean(axis=0)
+    if distance is None:
+        return float(np.linalg.norm(X - centroid, axis=1).mean())
+    return float(np.mean([distance(centroid, row) for row in X]))
+
 
 def diversity_text(
         data: list[str],
@@ -68,8 +83,3 @@ def diversity_text(
         for j in range(i + 1, n):
             tally += distance_function(X[i], X[j])
     return tally / (n * (n - 1) / 2)
-
-if __name__ == "__main__":
-    texts = ["how much money do i have", "my balance is what", "balance is my what"]
-    d = diversity_text(texts)
-    print(d)

--- a/splytters/report.py
+++ b/splytters/report.py
@@ -20,6 +20,7 @@ from sklearn.utils import check_random_state
 
 from splytters._types import Splitter
 from splytters.adversarial import get_cluster_info
+from splytters.metrics import diversity_text, mean_dist
 from splytters.utils import compute_split_similarity, validate_split_inputs
 
 
@@ -57,6 +58,7 @@ def split_report(
     test_indices: ArrayLike,
     y: ArrayLike | None = None,
     *,
+    texts: list[str] | None = None,
     metric: str = "euclidean",
     n_clusters: int = 10,
     max_samples: int | None = 2000,
@@ -69,6 +71,11 @@ def split_report(
     *more adversarial* (harder) split; values near a random split indicate a
     *balanced* split; near-zero indicates *overlap*.
 
+    Alongside these train↔test *distance* metrics, ``train_diversity`` and
+    ``test_diversity`` report the within-split *spread* (mean distance to each
+    side's own centroid) — useful for spotting when a split concentrates one
+    side (e.g. an adversarial test drawn from a single outlier cluster).
+
     Args:
         embeddings: array-like of shape (n_samples, n_features).
         train_indices: integer index array for the training split.
@@ -76,6 +83,10 @@ def split_report(
         y: array-like of labels, optional. If given, adds
             ``label_distribution_shift`` (total-variation distance between
             train/test class proportions; 0 = identical balance).
+        texts: per-sample raw strings, optional and aligned with ``embeddings``.
+            If given, adds ``train_text_diversity`` / ``test_text_diversity``
+            (mean pairwise n-gram distance within each side), subsampled to
+            ``max_samples`` for the O(n²) pairwise computation.
         metric: distance metric (default ``"euclidean"``).
         n_clusters: clusters used for the leakage statistic (default 10).
         max_samples: cap per side for the O(n²) distribution metrics
@@ -83,8 +94,8 @@ def split_report(
         random_state: seed for subsampling (default 42).
 
     Returns:
-        A dict of structural, geometric, distributional, and (optional) label
-        metrics.
+        A dict of structural, geometric, distributional, diversity, and
+        (optional) label metrics.
     """
     X = validate_split_inputs(embeddings, 0.5)  # reuse finite/2-D validation
     train_indices = np.asarray(train_indices, dtype=np.intp)
@@ -120,6 +131,23 @@ def split_report(
     report["ks_mean"] = float(
         np.mean([ks_2samp(A[:, d], B[:, d]).statistic for d in range(X.shape[1])])
     )
+
+    # Within-split diversity (spread): how varied is each side on its own.
+    report["train_diversity"] = mean_dist(X[train_indices])
+    report["test_diversity"] = mean_dist(X[test_indices])
+
+    # Optional text diversity: mean pairwise n-gram distance within each side.
+    if texts is not None:
+        texts = list(texts)
+        seed = random_state if isinstance(random_state, int) else 42
+        report["train_text_diversity"] = diversity_text(
+            [texts[i] for i in train_indices],
+            sample_size=max_samples, random_state=seed,
+        )
+        report["test_text_diversity"] = diversity_text(
+            [texts[i] for i in test_indices],
+            sample_size=max_samples, random_state=seed,
+        )
 
     # Label balance: total-variation distance between class proportions.
     if y is not None:

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -1,0 +1,59 @@
+"""Tests for string-distance primitives used by the diversity metrics."""
+
+import pytest
+
+from splytters.distances import (
+    difflib_character_similarity,
+    difflib_token_similarity,
+    ngram_jaccard_distance,
+    ngram_jaccard_similarity,
+    simple_tokenizer,
+)
+
+
+def test_simple_tokenizer_splits_on_whitespace():
+    assert simple_tokenizer("a b  c") == ["a", "b", "c"]
+    assert simple_tokenizer("") == []
+
+
+class TestNgramJaccard:
+
+    def test_identical_strings_are_maximally_similar(self):
+        assert ngram_jaccard_similarity("a b c d", "a b c d") == pytest.approx(1.0)
+
+    def test_disjoint_strings_are_dissimilar(self):
+        assert ngram_jaccard_similarity("a a a a", "b b b b") == pytest.approx(0.0)
+
+    def test_symmetric(self):
+        s1 = ngram_jaccard_similarity("the quick brown fox", "brown fox the quick")
+        s2 = ngram_jaccard_similarity("brown fox the quick", "the quick brown fox")
+        assert s1 == pytest.approx(s2)
+
+    def test_similarity_in_unit_interval(self):
+        s = ngram_jaccard_similarity("a b c d", "a b x y")
+        assert 0.0 <= s <= 1.0
+
+    def test_distance_is_one_minus_similarity(self):
+        a, b = "a b c d e", "a b x y z"
+        assert ngram_jaccard_distance(a, b) == pytest.approx(
+            1.0 - ngram_jaccard_similarity(a, b)
+        )
+
+    def test_distance_identical_is_zero(self):
+        assert ngram_jaccard_distance("a b c d", "a b c d") == pytest.approx(0.0)
+
+
+class TestDifflib:
+
+    def test_character_similarity_identical(self):
+        assert difflib_character_similarity("hello", "hello") == pytest.approx(1.0)
+
+    def test_character_similarity_disjoint(self):
+        assert difflib_character_similarity("aaaa", "bbbb") == pytest.approx(0.0)
+
+    def test_token_similarity_identical(self):
+        assert difflib_token_similarity("a b c", "a b c") == pytest.approx(1.0)
+
+    def test_token_similarity_partial(self):
+        s = difflib_token_similarity("a b c d", "a b x y")
+        assert 0.0 <= s <= 1.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,61 @@
+"""Tests for diversity metrics (within-set spread)."""
+
+import numpy as np
+import pytest
+
+from splytters.metrics import diversity_text, mean_dist
+
+
+class TestMeanDist:
+
+    def test_identical_points_have_zero_spread(self):
+        X = np.ones((10, 3))
+        assert mean_dist(X) == pytest.approx(0.0)
+
+    def test_matches_manual_euclidean(self):
+        rng = np.random.RandomState(0)
+        X = rng.randn(50, 4)
+        centroid = X.mean(axis=0)
+        expected = np.mean([np.linalg.norm(row - centroid) for row in X])
+        assert mean_dist(X) == pytest.approx(expected)
+
+    def test_more_spread_is_larger(self):
+        rng = np.random.RandomState(1)
+        tight = rng.randn(40, 2) * 0.1
+        wide = rng.randn(40, 2) * 5.0
+        assert mean_dist(wide) > mean_dist(tight)
+
+    def test_custom_distance_callable(self):
+        X = np.array([[0.0, 0.0], [2.0, 0.0], [4.0, 0.0]])
+
+        # Manhattan distance to centroid [2, 0]: |x-2| summed -> mean of 2,0,2.
+        def manhattan(u, v):
+            return float(np.abs(np.asarray(u) - np.asarray(v)).sum())
+
+        assert mean_dist(X, distance=manhattan) == pytest.approx((2 + 0 + 2) / 3)
+
+    def test_empty_returns_zero(self):
+        assert mean_dist(np.empty((0, 3))) == 0.0
+
+    def test_rejects_non_2d(self):
+        with pytest.raises(ValueError):
+            mean_dist(np.array([1.0, 2.0, 3.0]))
+
+
+class TestDiversityText:
+
+    def test_fewer_than_two_is_zero(self):
+        assert diversity_text([]) == 0.0
+        assert diversity_text(["only one"]) == 0.0
+
+    def test_identical_corpus_has_zero_diversity(self):
+        assert diversity_text(["a b c", "a b c", "a b c"]) == pytest.approx(0.0)
+
+    def test_varied_corpus_is_positive(self):
+        d = diversity_text(["the cat sat", "a dog ran", "blue green sky"])
+        assert d > 0.0
+
+    def test_subsampling_runs_and_is_bounded(self):
+        corpus = [f"word{i} token here" for i in range(30)]
+        d = diversity_text(corpus, sample_size=8, random_state=0)
+        assert 0.0 <= d <= 1.0

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -52,6 +52,27 @@ class TestSplitReport:
         assert adv["mean_cross_distance"] >= rand["mean_cross_distance"]
         assert adv["energy_distance"] >= rand["energy_distance"]
 
+    def test_diversity_keys_present_and_finite(self, embeddings_2d):
+        train, test = random_split(embeddings_2d)
+        rep = split_report(embeddings_2d, train, test)
+        for key in ("train_diversity", "test_diversity"):
+            assert key in rep
+            assert np.isfinite(rep[key]) and rep[key] >= 0.0
+
+    def test_text_diversity_reported_when_texts_given(self, embeddings_2d):
+        texts = [f"sample number {i} of the corpus" for i in range(len(embeddings_2d))]
+        train, test = random_split(embeddings_2d)
+        rep = split_report(embeddings_2d, train, test, texts=texts)
+        for key in ("train_text_diversity", "test_text_diversity"):
+            assert key in rep
+            assert 0.0 <= rep[key] <= 1.0
+
+    def test_text_diversity_absent_without_texts(self, embeddings_2d):
+        train, test = random_split(embeddings_2d)
+        rep = split_report(embeddings_2d, train, test)
+        assert "train_text_diversity" not in rep
+        assert "test_text_diversity" not in rep
+
     def test_label_shift_reported(self, embeddings_2d):
         y = np.array([0] * 60 + [1] * 60)
         train, test = random_split(embeddings_2d)


### PR DESCRIPTION
Wire the previously-orphaned diversity metrics into the public report path so split strategies can be compared on within-split spread, not just train/test separation:

- split_report() now emits train_diversity / test_diversity (mean distance to each side's centroid) and, when texts= is supplied, train_text_diversity / test_text_diversity (mean pairwise n-gram distance via diversity_text).
- Vectorize mean_dist (drop the per-sample Python loop) and validate input shape.
- Remove the redundant dist_euclidean from distances.py (the canonical, tested copy lives in sorters/embedding_sorters.py) plus dead simple_tokenizer / __main__ demo blocks.
- Add tests for distances.py and metrics.py (both now 100% covered); extend report tests for the new diversity fields.