### PR TITLE
test(adversarial,tabular): cover min_cut and tabular edge paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ docs = [
 all = ["splytters[text,image,audio,tabular,embedders,viz,demo,ann]"]
 dev = [
     "splytters[all,docs]",
+    "networkx",  # exact min-cut backend for min_cut_split(method="stoer_wagner")
     "pytest",
     "pytest-cov",
     "ruff",

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -627,6 +627,63 @@ class TestMinCutSplit:
         with pytest.raises(ValueError, match="Unknown method"):
             min_cut_split(embeddings_small, method="invalid")
 
+    def test_spectral_eigsh_failure_falls_back_to_random(
+        self, embeddings_small, monkeypatch
+    ):
+        """If eigendecomposition raises, the split falls back to a random one."""
+        def boom(*args, **kwargs):
+            raise RuntimeError("eigsh failed")
+        monkeypatch.setattr("splytters.adversarial.eigsh", boom)
+        train, test = min_cut_split(embeddings_small, method="spectral")
+        assert_valid_split(train, test, len(embeddings_small), ratio_tol=0.3)
+
+    def test_stoer_wagner_connected_graph(self, embeddings_small):
+        """A zero threshold keeps all edges -> one connected component, so the
+        exact Stoer-Wagner partition path runs."""
+        pytest.importorskip("networkx")
+        train, test = min_cut_split(
+            embeddings_small, method="stoer_wagner", similarity_threshold=0.0
+        )
+        assert_valid_split(train, test, len(embeddings_small), ratio_tol=0.4)
+
+    def test_stoer_wagner_connected_small_train(self, embeddings_small):
+        """A small train_size makes the cut's first partition large enough to
+        fill train directly (the `len(set1) >= n_train` branch)."""
+        pytest.importorskip("networkx")
+        train, test = min_cut_split(
+            embeddings_small, train_size=0.1,
+            method="stoer_wagner", similarity_threshold=0.0,
+        )
+        assert_valid_split(
+            train, test, len(embeddings_small), train_size=0.1, ratio_tol=0.5,
+        )
+
+    def test_stoer_wagner_disconnected_graph(self):
+        """Two tight, far-apart clusters with a high similarity threshold yield
+        a disconnected graph, exercising the connected-components branch."""
+        pytest.importorskip("networkx")
+        rng = np.random.RandomState(0)
+        a = rng.randn(10, 2) * 0.1 + np.array([0, 0])
+        b = rng.randn(10, 2) * 0.1 + np.array([100, 100])
+        X = np.vstack([a, b])
+        train, test = min_cut_split(
+            X, method="stoer_wagner", similarity_threshold=0.9
+        )
+        assert_valid_split(train, test, len(X), ratio_tol=0.5)
+
+    def test_stoer_wagner_missing_networkx_raises(self, embeddings_small, monkeypatch):
+        """Without networkx, the stoer_wagner method raises a clear ImportError."""
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "networkx":
+                raise ImportError("no networkx")
+            return real_import(name, *args, **kwargs)
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        with pytest.raises(ImportError, match="networkx is required"):
+            min_cut_split(embeddings_small, method="stoer_wagner")
+
 
 class TestNormalizedCutSplit:
 

--- a/tests/test_tabular_sorters.py
+++ b/tests/test_tabular_sorters.py
@@ -478,6 +478,85 @@ class TestEdgeCases:
         assert scores[1] == 0.0
         assert scores[2] == 0.0
 
+    # --- NaN handling in z-score sorters ---
+
+    def test_column_zscore_nan_goes_to_inf(self):
+        """A NaN cell scores +inf and sorts to the end (low_first)."""
+        df = pd.DataFrame({'a': [10.0, 20.0, 30.0, np.nan]})
+        results = column_zscore(df, 'a')
+        assert results[-1][0] == 3 and results[-1][1] == float('inf')
+
+    def test_column_absolute_zscore_constant_column(self):
+        """std == 0 returns all-zero scores."""
+        df = pd.DataFrame({'a': [7.0, 7.0, 7.0]})
+        results = column_absolute_zscore(df, 'a')
+        assert all(score == 0.0 for _, score in results)
+
+    def test_column_absolute_zscore_nan_goes_to_inf(self):
+        df = pd.DataFrame({'a': [10.0, 20.0, 30.0, np.nan]})
+        results = column_absolute_zscore(df, 'a')
+        assert results[-1][1] == float('inf')
+
+    # --- no-numeric-column fallbacks (return all-zero) ---
+
+    @pytest.fixture
+    def text_only_df(self):
+        return pd.DataFrame({'x': ['a', 'b', 'c'], 'y': ['p', 'q', 'r']})
+
+    def test_row_sparsity_no_numeric(self, text_only_df):
+        assert all(s == 0.0 for _, s in row_sparsity(text_only_df))
+
+    def test_outlier_score_no_numeric(self, text_only_df):
+        assert all(s == 0.0 for _, s in outlier_score(text_only_df))
+
+    def test_numerical_range_score_no_numeric(self, text_only_df):
+        assert all(s == 0.0 for _, s in numerical_range_score(text_only_df))
+
+    def test_row_distance_to_mean_no_numeric(self, text_only_df):
+        assert all(s == 0.0 for _, s in row_distance_to_mean(text_only_df))
+
+    def test_feature_entropy_no_categorical(self):
+        """A purely numeric frame has no categorical columns."""
+        df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+        assert all(s == 0.0 for _, s in feature_entropy(df))
+
+    # --- LOF outlier method ---
+
+    def test_outlier_score_lof_method(self):
+        rng = np.random.RandomState(0)
+        df = pd.DataFrame(rng.randn(20, 3), columns=['a', 'b', 'c'])
+        results = outlier_score(df, method='lof', n_neighbors=5)
+        assert len(results) == 20
+
+    # --- NaN in categorical sorters ---
+
+    def test_categorical_rarity_nan(self):
+        """NaN categories are treated as rarest (freq 0)."""
+        df = pd.DataFrame({'cat': ['A', 'A', 'B', None]})
+        scores = dict(categorical_rarity(df, 'cat'))
+        assert scores[3] == 0.0
+
+    def test_feature_entropy_nan(self):
+        """NaN categorical cells are treated as very rare."""
+        df = pd.DataFrame({'cat': ['A', 'A', 'B', None]})
+        results = feature_entropy(df, low_first=False)
+        # The NaN row should be among the highest-entropy (rarest) rows.
+        assert results[0][0] == 3
+
+    # --- multi_column_sort defaults / constant column ---
+
+    def test_multi_column_sort_default_weights(self):
+        df = pd.DataFrame({'a': [0, 50, 100], 'b': [100, 50, 0]})
+        results = multi_column_sort(df, ['a', 'b'])  # weights default to 1.0
+        assert len(results) == 3
+
+    def test_multi_column_sort_constant_column(self):
+        """A column with max == min normalizes to the 0.5 midpoint."""
+        df = pd.DataFrame({'a': [5, 5, 5], 'b': [0, 50, 100]})
+        results = multi_column_sort(df, ['a', 'b'], low_first=True)
+        indices = [idx for idx, _ in results]
+        assert indices == [0, 1, 2]  # ordered by 'b' since 'a' is flat
+
     def test_all_nan_column(self):
         """Should handle columns that are all NaN."""
         df = pd.DataFrame({


### PR DESCRIPTION
adversarial.py (85.7% -> ~95%): test min_cut_split's previously untested method="stoer_wagner" path (connected, disconnected, and missing-networkx-ImportError cases) and the spectral eigsh fallback. Add networkx to the dev extra so CI exercises the exact-min-cut backend.

tabular_sorters.py (83.5% -> 100%): cover the constant-column, NaN, no-numeric-column, LOF, and multi_column_sort default/flat-column branches across the sorter family.