### PR TITLE
fix: correctness bugs in bin splitters, sorters, and train-size resol…

### DIFF
--- a/splytters/balanced.py
+++ b/splytters/balanced.py
@@ -14,6 +14,7 @@ from scipy.stats import ks_2samp
 from sklearn.utils import check_random_state
 
 from splytters.utils import (
+    apportion_train,
     as_index_array,
     optimized_split,
     resolve_n_train,
@@ -120,16 +121,20 @@ def histogram_matched_split(
     embeddings = validate_split_inputs(embeddings, train_size)
     n_dims = embeddings.shape[1]
 
-    # Precompute bin edges for each dimension
+    # Precompute bin edges for each dimension. Skip degenerate dimensions whose
+    # percentile edges collapse (constant/near-constant features) — a zero-width
+    # bin makes density=True divide by zero and poison the score with NaN, which
+    # would silently stall the optimizer (every NaN comparison is False).
     bin_edges = [
         np.percentile(embeddings[:, d], np.linspace(0, 100, n_bins + 1))
         for d in range(n_dims)
     ]
+    valid_dims = [d for d in range(n_dims) if np.all(np.diff(bin_edges[d]) > 0)]
 
     def score_fn(X: np.ndarray, train: list[int], test: list[int]) -> float:
         train_data, test_data = X[train], X[test]
         total_diff = 0.0
-        for d in range(n_dims):
+        for d in valid_dims:
             train_hist, _ = np.histogram(train_data[:, d], bins=bin_edges[d], density=True)
             test_hist, _ = np.histogram(test_data[:, d], bins=bin_edges[d], density=True)
             total_diff += np.sum(np.abs(train_hist - test_hist))
@@ -214,22 +219,21 @@ def density_balanced_split(
     bin_edges = np.percentile(densities, np.linspace(0, 100, n_bins + 1))
     bin_assignments = np.digitize(densities, bin_edges[1:-1])
 
-    train_fraction = resolve_n_train(n_samples, train_size) / n_samples
+    n_train_total = resolve_n_train(n_samples, train_size)
+
+    # Apportion the global train target across non-empty density bins
+    # (largest-remainder) so the split hits train_size and never empties the
+    # test set, even when bins are singletons (n_bins >= n_samples).
+    bins = [b for b in (np.where(bin_assignments == i)[0] for i in range(n_bins))
+            if len(b) > 0]
+    per_bin_train = apportion_train([len(b) for b in bins], n_train_total)
 
     train_indices = []
     test_indices = []
-
-    # Sample proportionally from each bin
-    for bin_id in range(n_bins):
-        bin_samples = np.where(bin_assignments == bin_id)[0]
-        if len(bin_samples) == 0:
-            continue
-
+    for bin_samples, k in zip(bins, per_bin_train, strict=True):
         rng.shuffle(bin_samples)
-        n_train = max(1, int(len(bin_samples) * train_fraction))
-
-        train_indices.extend(bin_samples[:n_train].tolist())
-        test_indices.extend(bin_samples[n_train:].tolist())
+        train_indices.extend(bin_samples[:k].tolist())
+        test_indices.extend(bin_samples[k:].tolist())
 
     return as_index_array(train_indices), as_index_array(test_indices)
 

--- a/splytters/overlap.py
+++ b/splytters/overlap.py
@@ -16,6 +16,7 @@ from scipy.spatial.distance import cdist
 from sklearn.utils import check_random_state
 
 from splytters.utils import (
+    apportion_train,
     as_index_array,
     cluster_embeddings,
     compute_centroid,
@@ -57,21 +58,21 @@ def cluster_leak_split(
         embeddings, n_clusters, "kmeans", random_state, **cluster_kwargs
     )
 
+    n_samples = len(embeddings)
+    n_train_total = resolve_n_train(n_samples, train_size)
+
+    # Apportion the global train target across clusters (largest-remainder) so
+    # the realized split matches train_size instead of undershooting from
+    # per-cluster truncation.
+    clusters = [np.array(idx) for idx in cluster_to_indices.values()]
+    per_cluster_train = apportion_train([len(c) for c in clusters], n_train_total)
+
     train_indices = []
     test_indices = []
-
-    # Determine the per-cluster fraction to send to train.
-    n_samples = len(embeddings)
-    train_fraction = resolve_n_train(n_samples, train_size) / n_samples
-
-    # Split each cluster proportionally
-    for indices in cluster_to_indices.values():
-        indices = np.array(indices)
+    for indices, k in zip(clusters, per_cluster_train, strict=True):
         rng.shuffle(indices)
-
-        n_train = int(len(indices) * train_fraction)
-        train_indices.extend(indices[:n_train].tolist())
-        test_indices.extend(indices[n_train:].tolist())
+        train_indices.extend(indices[:k].tolist())
+        test_indices.extend(indices[k:].tolist())
 
     return as_index_array(train_indices), as_index_array(test_indices)
 
@@ -227,22 +228,21 @@ def stratified_similarity_split(
     bin_edges = np.percentile(distances, np.linspace(0, 100, n_bins + 1))
     bin_assignments = np.digitize(distances, bin_edges[1:-1])
 
-    train_fraction = resolve_n_train(len(embeddings), train_size) / len(embeddings)
+    n_train_total = resolve_n_train(len(embeddings), train_size)
+
+    # Collect non-empty bins, then apportion the global train target across them
+    # (largest-remainder) so the split hits train_size and never empties the
+    # test set, even when bins are singletons (n_bins >= n_samples).
+    bins = [b for b in (np.where(bin_assignments == i)[0] for i in range(n_bins))
+            if len(b) > 0]
+    per_bin_train = apportion_train([len(b) for b in bins], n_train_total)
 
     train_indices = []
     test_indices = []
-
-    # Sample proportionally from each bin
-    for bin_id in range(n_bins):
-        bin_samples = np.where(bin_assignments == bin_id)[0]
-        if len(bin_samples) == 0:
-            continue
-
+    for bin_samples, k in zip(bins, per_bin_train, strict=True):
         rng.shuffle(bin_samples)
-        n_train = max(1, int(len(bin_samples) * train_fraction))
-
-        train_indices.extend(bin_samples[:n_train].tolist())
-        test_indices.extend(bin_samples[n_train:].tolist())
+        train_indices.extend(bin_samples[:k].tolist())
+        test_indices.extend(bin_samples[k:].tolist())
 
     return as_index_array(train_indices), as_index_array(test_indices)
 

--- a/splytters/sorters/audio_sorters.py
+++ b/splytters/sorters/audio_sorters.py
@@ -185,7 +185,21 @@ def dynamic_range(
     scores = []
     for i, audio in enumerate(audios):
         y, _ = _load_audio(audio, sr)
-        dyn_range = np.abs(y).max() - np.abs(y).min()
+        y = np.asarray(y, dtype=float)
+        # Dynamic range = spread between the loudest and quietest parts *over
+        # time*. Measure it as the range of frame-wise RMS energy. Taking
+        # |amplitude|.min() instead is ~0 for any zero-crossing waveform, so it
+        # collapses to peak loudness and can't tell compressed from dynamic
+        # audio.
+        frame, hop = 2048, 512
+        if len(y) >= frame:
+            frames = np.lib.stride_tricks.sliding_window_view(y, frame)[::hop]
+            rms = np.sqrt(np.mean(frames ** 2, axis=1))
+        elif len(y) > 0:
+            rms = np.array([np.sqrt(np.mean(y ** 2))])
+        else:
+            rms = np.zeros(1)
+        dyn_range = float(rms.max() - rms.min())
         scores.append((i, dyn_range))
 
     scores.sort(key=lambda p: p[1], reverse=not low_first)

--- a/splytters/sorters/image_sorters.py
+++ b/splytters/sorters/image_sorters.py
@@ -144,6 +144,7 @@ def dominant_color(
     n_clusters: int = 5,
     target_color: list[int] | None = None,
     low_first: bool = True,
+    random_state: int = 42,
 ) -> list[tuple[int, float]]:
     """
     Sort images by their dominant color.
@@ -160,6 +161,7 @@ def dominant_color(
         target_color: RGB tuple to measure distance from (default [128, 128, 128] gray)
         low_first: if True, images closest to target color first;
                    if False, images furthest from target first
+        random_state: seed for the pixel subsample and k-means (default 42)
 
     Returns:
         List of (index, distance) tuples sorted by distance from target color.
@@ -176,13 +178,16 @@ def dominant_color(
         # Reshape to list of pixels
         pixels = rgb.reshape(-1, 3)
 
-        # Sample pixels if image is large (for speed)
+        # Sample pixels if image is large (for speed). Use a seeded generator
+        # so the subsample — and therefore the dominant color and the resulting
+        # ranking — is reproducible across calls (the global RNG was not).
         if len(pixels) > 10000:
-            indices = np.random.choice(len(pixels), 10000, replace=False)
+            rng = np.random.default_rng(random_state)
+            indices = rng.choice(len(pixels), 10000, replace=False)
             pixels = pixels[indices]
 
         # Find dominant colors via k-means
-        kmeans = KMeans(n_clusters=n_clusters, n_init="auto", random_state=42)
+        kmeans = KMeans(n_clusters=n_clusters, n_init="auto", random_state=random_state)
         kmeans.fit(pixels)
 
         # Get the most common cluster (dominant color)

--- a/splytters/utils.py
+++ b/splytters/utils.py
@@ -84,10 +84,55 @@ def validate_split_inputs(
 
 
 def resolve_n_train(n_samples: int, train_size: float | int) -> int:
-    """Resolve ``train_size`` (fraction or absolute count) to an int count."""
+    """Resolve ``train_size`` (fraction or absolute count) to an int count.
+
+    A fractional ``train_size`` is clamped to ``[1, n_samples - 1]`` so the
+    resolved count never collapses one side of the split to empty (e.g.
+    ``n_samples=2, train_size=0.3`` would otherwise truncate to 0).
+    """
     if isinstance(train_size, (int, np.integer)) and not isinstance(train_size, bool):
         return int(train_size)
-    return int(n_samples * train_size)
+    n_train = int(n_samples * train_size)
+    return min(max(n_train, 1), n_samples - 1)
+
+
+def apportion_train(bin_sizes: list[int], n_train_total: int) -> np.ndarray:
+    """Split ``n_train_total`` train slots across bins via largest-remainder.
+
+    Each bin gets ``floor(size * n_train_total / total)`` slots, then the
+    leftover slots go to the bins with the largest fractional remainders. The
+    per-bin counts sum exactly to ``n_train_total`` (clamped to ``[0, total]``),
+    avoiding both the per-bin ``int()`` truncation bias that undershoots the
+    requested train fraction and the all-to-train rounding that can empty the
+    test set.
+
+    Args:
+        bin_sizes: number of samples in each (non-empty) bin.
+        n_train_total: total samples to assign to train across all bins.
+
+    Returns:
+        Integer ndarray of per-bin train counts, aligned with ``bin_sizes``.
+    """
+    sizes = np.asarray(bin_sizes, dtype=np.intp)
+    total = int(sizes.sum())
+    if total == 0:
+        return np.zeros(len(sizes), dtype=np.intp)
+    n_train_total = int(min(max(n_train_total, 0), total))
+
+    ideal = sizes * (n_train_total / total)
+    counts = np.floor(ideal).astype(np.intp)
+    remainder = n_train_total - int(counts.sum())
+    if remainder > 0:
+        # Hand leftover slots to the largest fractional remainders that still
+        # have spare capacity (ideal <= size, so capacity always exists here).
+        order = np.argsort(-(ideal - np.floor(ideal)))
+        for i in order:
+            if remainder == 0:
+                break
+            if counts[i] < sizes[i]:
+                counts[i] += 1
+                remainder -= 1
+    return counts
 
 
 def as_index_array(indices: ArrayLike) -> np.ndarray:

--- a/tests/test_audio_sorters.py
+++ b/tests/test_audio_sorters.py
@@ -164,6 +164,22 @@ class TestDynamicRange:
 
         assert scores["dynamic_high"] > scores["dynamic_low"]
 
+    def test_dynamic_signal_scores_above_compressed(self):
+        """Frame-wise RMS range must rank a loud+quiet signal above a constant-
+        amplitude (compressed) one. Guards the old ``abs(y).min()`` ~ 0 bug that
+        collapsed dynamic_range to peak loudness."""
+        sr = 22050
+        t = np.linspace(0, 1, sr, endpoint=False)
+        compressed = 0.5 * np.sin(2 * np.pi * 440 * t)
+        dynamic = np.concatenate([
+            0.9 * np.sin(2 * np.pi * 440 * t[: sr // 2]),
+            0.02 * np.sin(2 * np.pi * 440 * t[sr // 2:]),
+        ])
+        results = dynamic_range([(compressed, sr), (dynamic, sr)], low_first=False)
+        scores = dict(results)
+        assert scores[1] > scores[0]  # dynamic (idx 1) has the larger range
+        assert results[0][0] == 1     # and sorts first with low_first=False
+
 
 class TestPeakToAverageRatio:
     """Tests for peak_to_average_ratio function."""

--- a/tests/test_image_sorters.py
+++ b/tests/test_image_sorters.py
@@ -176,6 +176,28 @@ class TestDominantColor:
             assert isinstance(distance, float)
             assert distance >= 0
 
+    def test_deterministic_on_large_image(self):
+        """Images over 10k pixels subsample their pixels; the ranking must be
+        reproducible across calls. Guards the old unseeded np.random.choice
+        subsample (KMeans contributes only ~1e-6 float jitter, which does not
+        reorder distinct images)."""
+        import numpy as np
+        from PIL import Image
+
+        rng = np.random.RandomState(0)
+        # 130*130 = 16900 pixels (> 10k) triggers the subsampling path.
+        imgs = [
+            Image.fromarray(rng.randint(0, 256, size=(130, 130, 3), dtype=np.uint8))
+            for _ in range(4)
+        ]
+        r1 = dominant_color(imgs)
+        r2 = dominant_color(imgs)
+        # Ranking identical, distances stable to within KMeans float jitter.
+        assert [i for i, _ in r1] == [i for i, _ in r2]
+        np.testing.assert_allclose(
+            [d for _, d in r1], [d for _, d in r2], rtol=1e-3
+        )
+
 
 class TestCompressionRatio:
     """Tests for compression_ratio function."""

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -39,6 +39,7 @@ from splytters.overlap import (
     stratified_similarity_split,
 )
 from splytters.utils import (
+    apportion_train,
     cluster_embeddings,
     compute_centroid,
     compute_pairwise_distances,
@@ -46,6 +47,7 @@ from splytters.utils import (
     compute_split_similarity,
     greedy_assign_to_target,
     random_split,
+    resolve_n_train,
     validate_split_inputs,
 )
 
@@ -1024,3 +1026,76 @@ class TestSklearnAlignment:
         train, test = random_split(X, train_size=0.7)
         assert isinstance(train, np.ndarray)
         assert len(train) + len(test) == 20
+
+
+# ===========================================================================
+# Regression tests for fixed correctness bugs
+# ===========================================================================
+
+class TestBinSplitApportionment:
+    """Bin/cluster splitters must never empty the test set and must hit the
+    requested train fraction (largest-remainder apportionment)."""
+
+    def test_apportion_train_sums_exactly(self):
+        counts = apportion_train([4, 4, 4, 4], 10)
+        assert counts.sum() == 10
+        assert all(0 <= c <= 4 for c in counts)
+
+    def test_apportion_singletons_leave_some_for_test(self):
+        # 12 singleton bins, target 8 train -> 8 bins train, 4 test.
+        counts = apportion_train([1] * 12, 8)
+        assert counts.sum() == 8
+        assert (counts == 0).sum() == 4
+
+    @pytest.mark.parametrize("splitter", [
+        stratified_similarity_split, density_balanced_split,
+    ])
+    def test_singleton_bins_do_not_empty_test(self, splitter):
+        """n_bins >= n_samples used to force every sample into train."""
+        X = np.random.RandomState(0).randn(12, 3)
+        train, test = splitter(X, train_size=0.7, n_bins=20)
+        assert len(test) > 0
+        assert_valid_split(train, test, 12, ratio_tol=0.25)
+
+    @pytest.mark.parametrize("splitter,kw", [
+        (stratified_similarity_split, {"n_bins": 10}),
+        (density_balanced_split, {"n_bins": 10}),
+        (cluster_leak_split, {"n_clusters": 8}),
+    ])
+    def test_hits_requested_train_fraction(self, splitter, kw):
+        """Per-bin int() truncation used to undershoot (got ~50% for 0.7)."""
+        X = np.random.RandomState(0).randn(40, 5)
+        train, test = splitter(X, train_size=0.7, **kw)
+        assert len(train) == 28  # resolve_n_train(40, 0.7)
+        assert_valid_split(train, test, 40, ratio_tol=0.05)
+
+
+class TestResolveNTrainClamp:
+
+    def test_small_fraction_never_empties_a_side(self):
+        # int(2 * 0.3) == 0 previously -> empty train.
+        assert resolve_n_train(2, 0.3) == 1
+        train, test = random_split(np.zeros((2, 4)), train_size=0.3)
+        assert_valid_split(train, test, 2, train_size=0.3, ratio_tol=0.5)
+
+    def test_normal_cases_unchanged(self):
+        assert resolve_n_train(10, 0.7) == 7
+        assert resolve_n_train(100, 0.9) == 90
+        assert resolve_n_train(100, 50) == 50  # absolute count passes through
+
+    def test_high_fraction_leaves_one_for_test(self):
+        assert resolve_n_train(10, 0.999) == 9
+
+
+class TestHistogramMatchedConstantDim:
+
+    def test_constant_dimension_does_not_produce_nan(self):
+        """A constant feature collapses percentile bin edges; density=True used
+        to divide by zero and NaN-poison the optimizer score."""
+        import warnings
+        X = np.random.RandomState(0).randn(30, 4)
+        X[:, 2] = 5.0  # constant dimension
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any RuntimeWarning fails the test
+            train, test = histogram_matched_split(X, train_size=0.6, n_iterations=30)
+        assert_valid_split(train, test, 30, train_size=0.6, ratio_tol=0.2)


### PR DESCRIPTION
…ution

Six verified bugs found in the repo bug scan, each with a regression test:

- overlap/balanced bin splitters could return an EMPTY test set when n_bins >= n_samples (per-bin `max(1, int(...))` forced every sample to train). Replaced per-bin/per-cluster truncation with a shared largest-remainder apportionment (utils.apportion_train) in stratified_similarity_split, density_balanced_split, cluster_leak_split — also fixes the systematic train-fraction undershoot (got ~50% for a requested 70%).
- resolve_n_train: clamp a fractional train_size to [1, n-1] so small-n splits never collapse one side to empty (e.g. n=2, 0.3 -> 0).
- histogram_matched_split: skip degenerate (constant) dimensions whose percentile bin edges collapse; density=True was dividing by zero and NaN-poisoning the optimizer score (silently stalling it).
- audio dynamic_range: was `abs(y).max() - abs(y).min()` ~= peak loudness (abs-min ~0 for any zero-crossing signal). Now frame-wise RMS range, so it actually distinguishes compressed from dynamic audio.
- image dominant_color: pixel subsample used the unseeded global RNG, so rankings were non-reproducible. Seeded via default_rng(random_state) plus a new random_state parameter.