### PR TITLE
fix: defensive guards for empty CV folds, empty reports, and length m…

### DIFF
--- a/splytters/adversarial.py
+++ b/splytters/adversarial.py
@@ -424,6 +424,18 @@ def cluster_kfold(
     for idx, label in enumerate(labels):
         cluster_to_indices[int(label)].append(idx)
 
+    # Folds are whole clusters, so we need at least n_folds distinct clusters.
+    # KMeans is guarded by the n_clusters check above, but DBSCAN chooses its
+    # own cluster count and can return fewer (e.g. one dense cluster plus a
+    # noise group), which would silently leave CV folds empty. Fail loudly.
+    n_found = len(cluster_to_indices)
+    if n_found < n_folds:
+        raise ValueError(
+            f"clustering produced only {n_found} cluster(s), fewer than "
+            f"n_folds={n_folds}, which would leave empty folds. Adjust the "
+            f"clustering (e.g. DBSCAN eps/min_samples) or reduce n_folds."
+        )
+
     classes = np.unique(y)
     class_idx = {c: k for k, c in enumerate(classes)}
 

--- a/splytters/report.py
+++ b/splytters/report.py
@@ -103,6 +103,13 @@ def split_report(
     rng = check_random_state(random_state)
 
     n_train, n_test = len(train_indices), len(test_indices)
+    # A report compares two non-empty sides; an empty side otherwise divides by
+    # zero here or crashes downstream in compute_split_similarity.
+    if n_train == 0 or n_test == 0:
+        raise ValueError(
+            f"split_report requires non-empty train and test splits "
+            f"(got n_train={n_train}, n_test={n_test})."
+        )
     report: dict[str, float] = {
         "n_train": float(n_train),
         "n_test": float(n_test),

--- a/splytters/sklearn_api.py
+++ b/splytters/sklearn_api.py
@@ -22,6 +22,7 @@ from typing import Any
 import numpy as np
 from sklearn.model_selection import BaseCrossValidator
 from sklearn.utils import _safe_indexing
+from sklearn.utils.validation import _num_samples
 
 from splytters._types import Splitter
 from splytters.adversarial import cluster_split
@@ -139,6 +140,16 @@ def splytter_train_test_split(
         if not arrays:
             raise ValueError("Pass at least one array or `embeddings=`.")
         embeddings = arrays[0]
+
+    # All inputs must align with the indices the splitter returns; mismatched
+    # lengths otherwise IndexError (longer) or silently drop rows (shorter).
+    n = _num_samples(embeddings)
+    for i, a in enumerate(arrays):
+        if _num_samples(a) != n:
+            raise ValueError(
+                f"All arrays must have the same length as embeddings ({n}); "
+                f"array {i} has length {_num_samples(a)}."
+            )
 
     train_idx, test_idx = splitter(
         embeddings, train_size=train_size, random_state=random_state, **splitter_kwargs

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -109,6 +109,12 @@ class TestTrainTestSplitConvenience:
         with pytest.raises(ValueError, match="at least one array"):
             splytter_train_test_split()
 
+    def test_mismatched_array_length_raises(self, labelled_data):
+        """An array whose length differs from embeddings is rejected up front."""
+        X, y = labelled_data
+        with pytest.raises(ValueError, match="same length"):
+            splytter_train_test_split(X, y[:-1], embeddings=X)
+
 
 # ---------------------------------------------------------------------------
 # Framework interop (lazily-imported deps)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -80,6 +80,16 @@ class TestSplitReport:
         assert "label_distribution_shift" in rep
         assert 0.0 <= rep["label_distribution_shift"] <= 1.0
 
+    def test_rejects_empty_split(self, embeddings_2d):
+        """An empty train or test side is rejected with a clear error rather
+        than a ZeroDivisionError / downstream crash."""
+        empty = np.array([], dtype=int)
+        full = np.arange(len(embeddings_2d))
+        with pytest.raises(ValueError, match="non-empty"):
+            split_report(embeddings_2d, empty, empty)
+        with pytest.raises(ValueError, match="non-empty"):
+            split_report(embeddings_2d, full, empty)
+
     def test_rejects_nan_embeddings(self, embeddings_2d):
         X = embeddings_2d.copy()
         X[0, 0] = np.nan

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -312,6 +312,16 @@ class TestClusterKFold:
         with pytest.raises(ValueError, match="at least"):
             cluster_kfold(embeddings_2d, labels, n_folds=5, n_clusters=3)
 
+    def test_dbscan_too_few_clusters_raises(self):
+        """DBSCAN picks its own cluster count; when it finds fewer than n_folds
+        (one dense blob + a noise group) folds would be left empty -> raise."""
+        blob = np.random.RandomState(0).randn(60, 2) * 0.05
+        noise = np.random.RandomState(99).randn(15, 2) * 30
+        X = np.vstack([blob, noise])
+        y = np.arange(len(X)) % 2
+        with pytest.raises(ValueError, match="fewer than"):
+            cluster_kfold(X, y, n_folds=4, method="dbscan", eps=0.5, min_samples=5)
+
     def test_unknown_method_raises(self, embeddings_2d, labels):
         with pytest.raises(ValueError, match="Unknown clustering method"):
             cluster_kfold(embeddings_2d, labels, method="nope")


### PR DESCRIPTION
…ismatch

Three safe hardening fixes from the bug scan (no behavior change on valid input — they convert silent failures into clear errors):

- cluster_kfold: raise when the realized clustering yields fewer clusters than n_folds. KMeans was guarded via n_clusters, but DBSCAN picks its own count and can return one dense cluster plus noise, silently leaving CV folds empty (breaking PredefinedSplit).
- split_report: reject an empty train or test side up front with a clear message instead of a ZeroDivisionError on train_fraction (and a later crash in compute_split_similarity).
- splytter_train_test_split: validate all arrays share embeddings' length, mirroring the interop helpers; otherwise a shorter array silently yields a truncated split.