### PR TITLE
feat(adversarial): add decision_boundary_split (supervised margin split)

### DIFF
--- a/splytters/__init__.py
+++ b/splytters/__init__.py
@@ -18,6 +18,7 @@ from splytters.adversarial import (
     class_boundary_split,
     cluster_kfold,
     cluster_split,
+    decision_boundary_split,
     density_adversarial_split,
     distance_adversarial_split,
     get_cluster_info,
@@ -103,6 +104,7 @@ __all__ = [
     "minority_split",
     "minority_grow_split",
     "class_boundary_split",
+    "decision_boundary_split",
     "get_cluster_info",
     # Clustering-based challenging cross-validation (returns per-sample fold ids)
     "cluster_kfold",
@@ -175,6 +177,7 @@ _SPLITTER_FAMILIES: dict[str, list[str]] = {
         "minority_split",
         "minority_grow_split",
         "class_boundary_split",
+        "decision_boundary_split",
     ],
     "overlap": [
         "cluster_leak_split",

--- a/splytters/adversarial.py
+++ b/splytters/adversarial.py
@@ -928,6 +928,161 @@ def class_boundary_split(
     return as_index_array(sorted(train)), as_index_array(sorted(test))
 
 
+def decision_boundary_split(
+    embeddings: ArrayLike,
+    y: ArrayLike,
+    train_size: float | int = 0.7,
+    *,
+    model: str = "linear_svc",
+    score: str = "confidence",
+    stratify: str = "per_class",
+    cv: int = 5,
+    random_state: int = 42,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Supervised adversarial split on a learned decision boundary.
+
+    Fits a fast linear classifier under cross-validation and routes the samples
+    a real model finds hardest -- those closest to the learned decision boundary
+    -- to the test set, leaving the confident, class-interior samples for train.
+    The learned-boundary counterpart to :func:`class_boundary_split` (which
+    instead measures geometric distance to other classes).
+
+    Hardness is scored *out of fold* via
+    :class:`~sklearn.model_selection.StratifiedKFold`: each sample's margin comes
+    from a model that did not train on it, so the score reflects genuine
+    difficulty rather than in-sample memorization.
+
+    Args:
+        embeddings: array-like of shape (n_samples, embedding_dim).
+        y: class labels of shape (n_samples,).
+        train_size: fraction in (0, 1) or absolute count. With
+            ``stratify="per_class"`` it sizes each class's train portion (so the
+            test set stays label-balanced); with ``"global"`` it sizes the whole
+            train set.
+        model: surrogate classifier, ``"linear_svc"``
+            (:class:`~sklearn.svm.LinearSVC`) or ``"logistic"``
+            (:class:`~sklearn.linear_model.LogisticRegression`). Each is
+            standardized via a per-fold :class:`~sklearn.preprocessing.StandardScaler`.
+        score: hardness measure. ``"confidence"`` (default) uses the top-1 minus
+            top-2 margin and works for both models; ``"entropy"`` uses predictive
+            entropy and requires probabilities (``model="logistic"`` only).
+        stratify: ``"per_class"`` (default; per-class test quota -> label-balanced
+            test) or ``"global"`` (purest-hard; may unbalance classes).
+        cv: number of cross-validation folds, clamped to the smallest class
+            count. Each fold supplies the out-of-fold margins for its held-out
+            samples.
+        random_state: seeds the fold shuffling and the classifier; the split is
+            deterministic (ties broken by index).
+
+    Returns:
+        train_indices: ndarray of confident, class-interior sample indices.
+        test_indices: ndarray of near-boundary, model-confusable indices.
+
+    Raises:
+        ValueError: on a ``y``/embeddings length mismatch, fewer than two
+            distinct classes, an unknown ``model``/``score``/``stratify``, an
+            ``entropy`` score with ``linear_svc``, or a class with fewer than two
+            samples (too small to hold out).
+
+    References:
+        Uncertainty / margin sampling from active learning (Lewis & Gale, 1994;
+        Scheffer et al., 2001; Settles, 2009). Like :func:`class_boundary_split`,
+        a label-aware variant of the hard-split motivation of Soegaard et al.
+        (2021), "We Need to Talk About Random Splits"
+        (https://aclanthology.org/2021.eacl-main.156), but using a *learned*
+        boundary rather than embedding geometry.
+    """
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.model_selection import StratifiedKFold
+    from sklearn.pipeline import make_pipeline
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.svm import LinearSVC
+
+    if model not in ("linear_svc", "logistic"):
+        raise ValueError(f"model must be 'linear_svc' or 'logistic', got {model!r}")
+    if score not in ("confidence", "entropy"):
+        raise ValueError(f"score must be 'confidence' or 'entropy', got {score!r}")
+    if stratify not in ("per_class", "global"):
+        raise ValueError(f"stratify must be 'per_class' or 'global', got {stratify!r}")
+    if score == "entropy" and model != "logistic":
+        raise ValueError("score='entropy' needs predict_proba; use model='logistic'.")
+
+    embeddings = validate_split_inputs(embeddings, train_size)
+    y = np.asarray(y)
+    n_samples = len(embeddings)
+    if len(y) != n_samples:
+        raise ValueError(f"y has length {len(y)} but embeddings has {n_samples} rows")
+
+    classes, counts = np.unique(y, return_counts=True)
+    if len(classes) < 2:
+        raise ValueError(
+            f"need at least 2 distinct classes for a boundary split, got {len(classes)}"
+        )
+    if counts.min() < 2:
+        raise ValueError(
+            "every class needs >= 2 samples for out-of-fold margins; smallest "
+            f"class has {int(counts.min())}."
+        )
+
+    n_folds = min(cv, int(counts.min()))
+
+    def make_clf():
+        clf = (
+            LinearSVC(random_state=random_state)
+            if model == "linear_svc"
+            else LogisticRegression(max_iter=1000, random_state=random_state)
+        )
+        return make_pipeline(StandardScaler(), clf)
+
+    # Out-of-fold hardness: higher == closer to the boundary == harder.
+    hardness = np.empty(n_samples, dtype=float)
+    skf = StratifiedKFold(n_splits=n_folds, shuffle=True, random_state=random_state)
+    for fit_idx, hold_idx in skf.split(embeddings, y):
+        pipe = make_clf()
+        pipe.fit(embeddings[fit_idx], y[fit_idx])
+        Xh = embeddings[hold_idx]
+
+        if score == "entropy":
+            P = pipe.predict_proba(Xh)
+            hardness[hold_idx] = -np.sum(P * np.log(P + 1e-12), axis=1)
+            continue
+
+        if model == "logistic":
+            margins = pipe.predict_proba(Xh)
+        else:
+            D = pipe.decision_function(Xh)
+            if D.ndim == 1:  # binary: distance to the single hyperplane
+                hardness[hold_idx] = -np.abs(D)
+                continue
+            # Multiclass OvR: normalize each column to a geometric distance by
+            # its own ||w_k|| so the cross-class top1 - top2 margin is comparable.
+            coef = pipe[-1].coef_
+            margins = D / np.linalg.norm(coef, axis=1)
+
+        top2 = np.sort(margins, axis=1)[:, -2:]
+        hardness[hold_idx] = -(top2[:, 1] - top2[:, 0])
+
+    # Route the hardest samples to test (stable sort -> ties broken by index).
+    if stratify == "global":
+        n_test = n_samples - resolve_n_train(n_samples, train_size)
+        test_idx = np.argsort(-hardness, kind="stable")[:n_test]
+        test_set = set(test_idx.tolist())
+    else:
+        test_set = set()
+        for k in classes:
+            members = np.flatnonzero(y == k)
+            n_train_k = min(resolve_n_train(len(members), train_size), len(members))
+            n_test_k = len(members) - n_train_k
+            if n_test_k <= 0:
+                continue
+            order = np.argsort(-hardness[members], kind="stable")
+            test_set.update(members[order[:n_test_k]].tolist())
+
+    train = [i for i in range(n_samples) if i not in test_set]
+    return as_index_array(train), as_index_array(sorted(test_set))
+
+
 def distance_adversarial_split(
     embeddings: ArrayLike,
     train_size: float | int = 0.7,

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -10,6 +10,7 @@ from splytters.adversarial import (
     class_boundary_split,
     cluster_kfold,
     cluster_split,
+    decision_boundary_split,
     density_adversarial_split,
     distance_adversarial_split,
     get_cluster_info,
@@ -532,6 +533,99 @@ class TestClassBoundarySplit:
         X, y = two_lines
         with pytest.raises(ValueError, match="reference must be"):
             class_boundary_split(X, y, reference="nope")
+
+
+class TestDecisionBoundarySplit:
+    """Supervised learned-boundary split: lowest-margin samples -> test."""
+
+    @pytest.fixture
+    def two_lines(self):
+        """Binary, separable along x; samples nearest x=10 are hardest."""
+        x = np.concatenate([np.arange(0, 10), np.arange(11, 21)]).astype(float)
+        X = np.column_stack([x, np.zeros_like(x)])
+        y = np.array([0] * 10 + [1] * 10)
+        return X, y
+
+    @pytest.fixture
+    def three_blobs(self):
+        rng = np.random.RandomState(0)
+        X = np.vstack([
+            rng.randn(30, 5) + np.array([4, 0, 0, 0, 0]),
+            rng.randn(30, 5) + np.array([0, 4, 0, 0, 0]),
+            rng.randn(30, 5) + np.array([0, 0, 4, 0, 0]),
+        ])
+        y = np.array([0] * 30 + [1] * 30 + [2] * 30)
+        return X, y
+
+    @pytest.mark.parametrize("model", ["linear_svc", "logistic"])
+    @pytest.mark.parametrize("stratify", ["per_class", "global"])
+    def test_valid_split_binary(self, two_lines, model, stratify):
+        X, y = two_lines
+        train, test = decision_boundary_split(
+            X, y, model=model, stratify=stratify, random_state=0
+        )
+        assert_valid_split(train, test, len(X), ratio_tol=0.1)
+
+    @pytest.mark.parametrize("model", ["linear_svc", "logistic"])
+    def test_valid_split_multiclass(self, three_blobs, model):
+        X, y = three_blobs
+        train, test = decision_boundary_split(X, y, model=model, random_state=0)
+        assert_valid_split(train, test, len(X), ratio_tol=0.1)
+
+    @pytest.mark.parametrize("model", ["linear_svc", "logistic"])
+    def test_boundary_samples_go_to_test(self, two_lines, model):
+        """The samples nearest the learned boundary (x=10) are the hardest."""
+        X, y = two_lines
+        _, test = decision_boundary_split(X, y, train_size=0.7, model=model)
+        assert set(test.tolist()) == {7, 8, 9, 10, 11, 12}
+
+    def test_per_class_is_label_balanced(self, three_blobs):
+        X, y = three_blobs
+        _, test = decision_boundary_split(X, y, train_size=0.7, stratify="per_class")
+        assert [int((y[test] == k).sum()) for k in (0, 1, 2)] == [9, 9, 9]
+
+    def test_entropy_score_with_logistic(self, three_blobs):
+        X, y = three_blobs
+        train, test = decision_boundary_split(
+            X, y, model="logistic", score="entropy", random_state=0
+        )
+        assert_valid_split(train, test, len(X), ratio_tol=0.1)
+
+    def test_deterministic(self, three_blobs):
+        X, y = three_blobs
+        assert _splits_equal(
+            decision_boundary_split(X, y, random_state=1),
+            decision_boundary_split(X, y, random_state=1),
+        )
+
+    def test_entropy_requires_logistic(self, two_lines):
+        X, y = two_lines
+        with pytest.raises(ValueError, match="entropy"):
+            decision_boundary_split(X, y, model="linear_svc", score="entropy")
+
+    def test_single_class_raises(self, two_lines):
+        X, _ = two_lines
+        with pytest.raises(ValueError, match="at least 2"):
+            decision_boundary_split(X, np.zeros(len(X), dtype=int))
+
+    def test_y_length_mismatch_raises(self, two_lines):
+        X, y = two_lines
+        with pytest.raises(ValueError, match="length"):
+            decision_boundary_split(X, y[:-1])
+
+    def test_class_too_small_to_hold_out_raises(self):
+        X = np.random.RandomState(0).randn(11, 3)
+        y = np.array([0] * 10 + [1])  # class 1 has a single sample
+        with pytest.raises(ValueError, match="2 samples"):
+            decision_boundary_split(X, y)
+
+    @pytest.mark.parametrize("kw", [
+        {"model": "x"}, {"score": "x"}, {"stratify": "x"},
+    ])
+    def test_unknown_options_raise(self, two_lines, kw):
+        X, y = two_lines
+        with pytest.raises(ValueError):
+            decision_boundary_split(X, y, **kw)
 
 
 class TestMMDMaximizedSplit:


### PR DESCRIPTION
A supervised adversarial splitter: fit a fast linear classifier under cross-validation and route the lowest-margin (most boundary-confusable) samples to test. The learned-boundary counterpart to class_boundary_split (which uses embedding geometry).

- Out-of-fold margins via StratifiedKFold so hardness reflects genuine difficulty, not in-sample memorization.
- model="linear_svc" | "logistic"; standardized per fold.
- score="confidence" (top1-top2, both models) | "entropy" (logistic only). Multiclass LinearSVC margins are normalized by ||w_k|| per fold to make the cross-class top1-top2 a true geometric distance.
- stratify="per_class" (default, label-balanced test) | "global".
- Registered in __init__ and the adversarial family.