### PR TITLE
feat(adversarial): add rbf_svc surrogate to decision_boundary_split

### DIFF
--- a/splytters/adversarial.py
+++ b/splytters/adversarial.py
@@ -972,10 +972,15 @@ def decision_boundary_split(
             ``stratify="per_class"`` it sizes each class's train portion (so the
             test set stays label-balanced); with ``"global"`` it sizes the whole
             train set.
-        model: surrogate classifier, ``"linear_svc"``
-            (:class:`~sklearn.svm.LinearSVC`) or ``"logistic"``
-            (:class:`~sklearn.linear_model.LogisticRegression`). Each is
-            standardized via a per-fold :class:`~sklearn.preprocessing.StandardScaler`.
+        model: surrogate classifier -- ``"linear_svc"`` (default,
+            :class:`~sklearn.svm.LinearSVC`), ``"logistic"``
+            (:class:`~sklearn.linear_model.LogisticRegression`), or ``"rbf_svc"``
+            (kernel SVM, :class:`~sklearn.svm.SVC` with an RBF kernel and
+            ``gamma="scale"``). The linear models are fast; ``"rbf_svc"`` captures
+            non-linear boundaries -- and finds genuinely harder splits on
+            non-linearly-separable embeddings -- but costs O(n^2)+ per fold, so
+            reserve it for smaller n. Each is standardized via a per-fold
+            :class:`~sklearn.preprocessing.StandardScaler`.
         score: hardness measure. ``"confidence"`` (default) uses the top-1 minus
             top-2 margin and works for both models; ``"entropy"`` uses predictive
             entropy and requires probabilities (``model="logistic"`` only).
@@ -1009,10 +1014,12 @@ def decision_boundary_split(
     from sklearn.model_selection import StratifiedKFold
     from sklearn.pipeline import make_pipeline
     from sklearn.preprocessing import StandardScaler
-    from sklearn.svm import LinearSVC
+    from sklearn.svm import SVC, LinearSVC
 
-    if model not in ("linear_svc", "logistic"):
-        raise ValueError(f"model must be 'linear_svc' or 'logistic', got {model!r}")
+    if model not in ("linear_svc", "logistic", "rbf_svc"):
+        raise ValueError(
+            f"model must be 'linear_svc', 'logistic', or 'rbf_svc', got {model!r}"
+        )
     if score not in ("confidence", "entropy"):
         raise ValueError(f"score must be 'confidence' or 'entropy', got {score!r}")
     if stratify not in ("per_class", "global"):
@@ -1040,11 +1047,13 @@ def decision_boundary_split(
     n_folds = min(cv, int(counts.min()))
 
     def make_clf():
-        clf = (
-            LinearSVC(random_state=random_state)
-            if model == "linear_svc"
-            else LogisticRegression(max_iter=1000, random_state=random_state)
-        )
+        if model == "linear_svc":
+            clf = LinearSVC(random_state=random_state)
+        elif model == "rbf_svc":
+            clf = SVC(kernel="rbf", decision_function_shape="ovr",
+                      random_state=random_state)
+        else:
+            clf = LogisticRegression(max_iter=1000, random_state=random_state)
         return make_pipeline(StandardScaler(), clf)
 
     # Out-of-fold hardness: higher == closer to the boundary == harder.
@@ -1062,15 +1071,18 @@ def decision_boundary_split(
 
         if model == "logistic":
             margins = pipe.predict_proba(Xh)
-        else:
+        else:  # linear_svc or rbf_svc
             D = pipe.decision_function(Xh)
-            if D.ndim == 1:  # binary: distance to the single hyperplane
+            if D.ndim == 1:  # binary: distance to the single boundary
                 hardness[hold_idx] = -np.abs(D)
                 continue
-            # Multiclass OvR: normalize each column to a geometric distance by
-            # its own ||w_k|| so the cross-class top1 - top2 margin is comparable.
-            coef = pipe[-1].coef_
-            margins = D / np.linalg.norm(coef, axis=1)
+            if model == "linear_svc":
+                # Normalize each OvR column to a geometric distance by its own
+                # ||w_k|| so the cross-class top1 - top2 is comparable. The RBF
+                # SVC has no coef_; its OvR decision_function is already
+                # vote-aggregated across classes, so it is used as-is.
+                D = D / np.linalg.norm(pipe[-1].coef_, axis=1)
+            margins = D
 
         top2 = np.sort(margins, axis=1)[:, -2:]
         hardness[hold_idx] = -(top2[:, 1] - top2[:, 0])

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -567,7 +567,7 @@ class TestDecisionBoundarySplit:
         y = np.array([0] * 30 + [1] * 30 + [2] * 30)
         return X, y
 
-    @pytest.mark.parametrize("model", ["linear_svc", "logistic"])
+    @pytest.mark.parametrize("model", ["linear_svc", "logistic", "rbf_svc"])
     @pytest.mark.parametrize("stratify", ["per_class", "global"])
     def test_valid_split_binary(self, two_lines, model, stratify):
         X, y = two_lines
@@ -576,11 +576,24 @@ class TestDecisionBoundarySplit:
         )
         assert_valid_split(train, test, len(X), ratio_tol=0.1)
 
-    @pytest.mark.parametrize("model", ["linear_svc", "logistic"])
+    @pytest.mark.parametrize("model", ["linear_svc", "logistic", "rbf_svc"])
     def test_valid_split_multiclass(self, three_blobs, model):
         X, y = three_blobs
         train, test = decision_boundary_split(X, y, model=model, random_state=0)
         assert_valid_split(train, test, len(X), ratio_tol=0.1)
+
+    def test_rbf_concentrates_on_nonlinear_boundary(self):
+        """On concentric circles (no linear boundary), the RBF surrogate routes
+        test points tightly onto the true circular boundary, where the linear
+        surrogate -- which has no meaningful boundary -- scatters them."""
+        from sklearn.datasets import make_circles
+
+        X, y = make_circles(n_samples=400, noise=0.08, factor=0.5, random_state=0)
+        radii = {}
+        for model in ("linear_svc", "rbf_svc"):
+            _, test = decision_boundary_split(X, y, model=model, random_state=0)
+            radii[model] = np.sqrt((X[test] ** 2).sum(axis=1)).std()
+        assert radii["rbf_svc"] < radii["linear_svc"]
 
     @pytest.mark.parametrize("model", ["linear_svc", "logistic"])
     def test_boundary_samples_go_to_test(self, two_lines, model):
@@ -608,10 +621,11 @@ class TestDecisionBoundarySplit:
             decision_boundary_split(X, y, random_state=1),
         )
 
-    def test_entropy_requires_logistic(self, two_lines):
+    @pytest.mark.parametrize("model", ["linear_svc", "rbf_svc"])
+    def test_entropy_requires_logistic(self, two_lines, model):
         X, y = two_lines
         with pytest.raises(ValueError, match="entropy"):
-            decision_boundary_split(X, y, model="linear_svc", score="entropy")
+            decision_boundary_split(X, y, model=model, score="entropy")
 
     def test_single_class_raises(self, two_lines):
         X, _ = two_lines


### PR DESCRIPTION
Adds model="rbf_svc" (SVC with an RBF kernel) alongside linear_svc and logistic, so the learned-boundary split can capture non-linear decision surfaces. The RBF SVC has no coef_, so the multiclass margin uses its OvR decision_function directly (already vote-aggregated across classes) rather than the ||w_k|| geometric normalization used for linear_svc; binary uses |decision_function| as before. Entropy stays logistic-only (SVC needs probability=True, an expensive/stochastic extra). Costs O(n^2)+ per fold, documented.

On concentric circles (no linear boundary) rbf_svc routes test points tightly onto the true circular boundary where linear_svc scatters them (new regression test).