### PR TITLE
docs: host on Read the Docs instead of personal GitHub Pages

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs build configuration.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+# Install the package (its core deps) plus the docs extra so mkdocstrings can
+# import splytters and render its docstrings.
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/splytters.svg)](https://pypi.org/project/splytters/)
 [![CI](https://github.com/gxlarson/splytters/actions/workflows/ci.yml/badge.svg)](https://github.com/gxlarson/splytters/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/gxlarson/splytters/branch/main/graph/badge.svg)](https://codecov.io/gh/gxlarson/splytters)
-[![Docs](https://img.shields.io/badge/docs-online-blue.svg)](https://gxlarson.github.io/splytters/)
+[![Docs](https://readthedocs.org/projects/splytters/badge/?version=latest)](https://splytters.readthedocs.io/en/latest/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/gxlarson/splytters/blob/main/LICENSE)
 [![Python](https://img.shields.io/pypi/pyversions/splytters.svg)](https://pypi.org/project/splytters/)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: splytters
 site_description: >-
   Clustering-based data splits for model robustness testing: adversarial,
   overlap, and distribution-balanced train-test splitting.
-site_url: https://gxlarson.github.io/splytters/
+site_url: https://splytters.readthedocs.io/
 repo_url: https://github.com/gxlarson/splytters
 repo_name: gxlarson/splytters
 copyright: Copyright &copy; Stefan Larson


### PR DESCRIPTION
Add .readthedocs.yaml (mkdocs build, installs the package + docs extra so mkdocstrings can import splytters), point site_url and the README docs badge at splytters.readthedocs.io. The GitHub Pages workflow is left in place for now; retire it once RTD is confirmed building.