### PR TITLE
ci(docs): retire GitHub Pages deploy; keep strict build check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,25 +1,19 @@
 name: docs
 
+# Read the Docs hosts the published site (splytters.readthedocs.io). This
+# workflow only validates that the docs build cleanly — it does not deploy.
 on:
   push:
     branches: [main]
-  # Manual "Run workflow" button in the Actions tab.
+  pull_request:
   workflow_dispatch:
 
-# Allow the workflow to deploy to GitHub Pages.
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-# One concurrent deploy; don't cancel an in-progress one.
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
   build:
-    name: build site
+    name: build (strict)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,17 +27,3 @@ jobs:
         run: pip install -e ".[docs]"
       - name: Build (strict — fail on warnings/broken refs)
         run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-  deploy:
-    name: deploy to Pages
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Read the Docs now hosts the published site, so drop the Pages deploy job and its pages/id-token permissions. Keep the strict mkdocs build as a validation gate and add a pull_request trigger so broken docs are caught in PRs, not just on main.