### PR TITLE
ci: add wheel-install smoke test (CI job + pre-publish gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,43 @@ jobs:
       - name: Core + interop + report tests
         run: pytest tests/test_splitters.py tests/test_interop.py tests/test_report.py -q
 
+  # Verify the BUILT wheel installs into a clean environment and imports. The
+  # editable (`-e .`) installs above keep the source tree on sys.path, so they
+  # can't catch a wheel missing a subpackage / py.typed, or a dependency that
+  # won't resolve from scratch.
+  package:
+    name: package (wheel install smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Install the built wheel into a clean venv
+        run: |
+          python -m venv /tmp/venv
+          /tmp/venv/bin/pip install dist/*.whl
+      - name: Smoke-import the installed wheel (outside the source tree)
+        run: |
+          cat > /tmp/smoke.py <<'PY'
+          import os
+          import numpy as np
+          import splytters
+          print("splitters:", len(splytters.list_splitters()))
+          tr, te = splytters.cluster_split(np.random.rand(120, 8), train_size=0.7)
+          assert len(tr) + len(te) == 120
+          import splytters.sorters  # lazy subpackage must ship in the wheel
+          assert os.path.exists(
+              os.path.join(os.path.dirname(splytters.__file__), "py.typed")
+          ), "py.typed missing from the installed wheel"
+          print("wheel install OK")
+          PY
+          cd /tmp && /tmp/venv/bin/python /tmp/smoke.py
+
   # Lint with ruff.
   lint:
     name: lint (ruff)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,5 +33,11 @@ jobs:
           python -m pip install --upgrade twine
           python -m twine check dist/*
 
+      - name: Verify the wheel installs and imports in a clean venv
+        run: |
+          python -m venv /tmp/venv
+          /tmp/venv/bin/pip install dist/*.whl
+          cd /tmp && /tmp/venv/bin/python -c "import splytters; splytters.list_splitters(); import splytters.sorters; print('install ok')"
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The existing jobs all install with `pip install -e .` (editable), which keeps the source tree on sys.path and so can't catch a built wheel that is missing a subpackage / py.typed or has unresolvable deps.

- ci.yml: new `package` job builds the wheel, installs it into a clean venv, and smoke-imports it from OUTSIDE the source tree (verifying list_splitters/cluster_split/splytters.sorters and the py.typed marker).
- publish.yml: same install-and-import check gates the upload, so a broken wheel can never reach PyPI (stronger than twine check alone).

Verified locally: wheel imports from site-packages, not the source tree.