### PR TITLE
feat(splitters): add group_split, deduplicated_split, maximin_split

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ distance, mean 1-D Wasserstein/KS, and optional label-distribution shift).
 ## Available splitters
 
 **Adversarial** (minimize train/test similarity):
-`cluster_split`, `centroid_adversarial_split`, `distance_adversarial_split`, `density_adversarial_split`, `outlier_adversarial_split`, `min_cut_split`, `normalized_cut_split`, `wasserstein_adversarial_split`, `mmd_maximized_split`, `minority_split`, `class_boundary_split`
+`cluster_split`, `centroid_adversarial_split`, `distance_adversarial_split`, `density_adversarial_split`, `outlier_adversarial_split`, `min_cut_split`, `normalized_cut_split`, `wasserstein_adversarial_split`, `mmd_maximized_split`, `minority_split`, `class_boundary_split`, `decision_boundary_split`, `maximin_split`
 
 ![Adversarial splitters on 2D distributions](https://raw.githubusercontent.com/gxlarson/splytters/main/docs/adv.png)
 
@@ -140,8 +140,11 @@ distance, mean 1-D Wasserstein/KS, and optional label-distribution shift).
 
 ![Balanced splitters on 2D distributions](https://raw.githubusercontent.com/gxlarson/splytters/main/docs/bal.png)
 
+**Grouped** (keep related samples / near-duplicates on one side, preventing leakage):
+`group_split` (explicit group ids), `deduplicated_split` (discovered near-duplicates)
+
 **Supervised** (label-aware — these take class labels `y`):
-`class_boundary_split`, `minority_split`, `stratified_random_split`, `sorted_stratified_split`, `cluster_split(strategy="subset_sum")`
+`class_boundary_split`, `decision_boundary_split`, `minority_split`, `stratified_random_split`, `sorted_stratified_split`, `cluster_split(strategy="subset_sum")`
 
 ![Supervised splitters on labeled 2D distributions](https://raw.githubusercontent.com/gxlarson/splytters/main/docs/supervised.png)
 

--- a/splytters/__init__.py
+++ b/splytters/__init__.py
@@ -22,6 +22,7 @@ from splytters.adversarial import (
     density_adversarial_split,
     distance_adversarial_split,
     get_cluster_info,
+    maximin_split,
     min_cut_split,
     minority_grow_split,
     minority_split,
@@ -44,6 +45,9 @@ from splytters.curriculum import sorted_stratified_split
 
 # Embedder discovery (heavy model libs stay lazy; listing needs no extra).
 from splytters.embedders import list_embedders
+
+# Grouping-aware splits (keep related samples / near-duplicates on one side).
+from splytters.grouped import deduplicated_split, group_split
 
 # Framework interop (pandas / torch / HuggingFace datasets). Heavy deps are
 # imported lazily inside each helper, so this import stays dependency-light.
@@ -105,6 +109,7 @@ __all__ = [
     "minority_grow_split",
     "class_boundary_split",
     "decision_boundary_split",
+    "maximin_split",
     "get_cluster_info",
     # Clustering-based challenging cross-validation (returns per-sample fold ids)
     "cluster_kfold",
@@ -125,6 +130,9 @@ __all__ = [
     "mmd_minimized_split",
     # Baseline
     "random_split",
+    # Grouped (keep related samples / near-duplicates on one side)
+    "group_split",
+    "deduplicated_split",
     # Curriculum (ordering-driven; pair with a splytters.sorters ranking)
     "sorted_stratified_split",
     # Stratify any embedding splitter / sorter by class (coverage-safe wrappers)
@@ -178,6 +186,7 @@ _SPLITTER_FAMILIES: dict[str, list[str]] = {
         "minority_grow_split",
         "class_boundary_split",
         "decision_boundary_split",
+        "maximin_split",
     ],
     "overlap": [
         "cluster_leak_split",
@@ -199,6 +208,10 @@ _SPLITTER_FAMILIES: dict[str, list[str]] = {
     "baseline": [
         "random_split",
     ],
+    "grouped": [
+        "group_split",
+        "deduplicated_split",
+    ],
 }
 
 
@@ -207,9 +220,9 @@ def list_splitters(by_family: bool = False) -> list[str] | dict[str, list[str]]:
 
     Args:
         by_family: if True, return a dict mapping each family
-            ("adversarial", "overlap", "balanced", "baseline") to its list of
-            splitter names. If False (default), return a flat list of every
-            splitter name, in family order.
+            ("adversarial", "overlap", "balanced", "baseline", "grouped") to its
+            list of splitter names. If False (default), return a flat list of
+            every splitter name, in family order.
 
     Returns:
         A flat list of names, or a dict of family -> names.

--- a/splytters/adversarial.py
+++ b/splytters/adversarial.py
@@ -1615,3 +1615,58 @@ def get_cluster_info(
         "clusters_with_leakage": total_leaking,
         "leakage_ratio": total_leaking / n_clusters
     }
+
+
+def maximin_split(
+    embeddings: ArrayLike,
+    train_size: float | int = 0.7,
+    metric: str = "euclidean",
+    random_state: int = 42,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Adversarial split via farthest-point (k-center) test selection.
+
+    Builds the test set by greedy farthest-first traversal: seed with one point,
+    then repeatedly add the point farthest (``metric``) from everything already
+    selected. The result is a maximally *spread-out* test set that covers the
+    corners and extremes of the embedding space — a diverse, hard evaluation
+    that, unlike a random sample, never under-represents sparse / outlying
+    regions. Train is the (denser) remainder.
+
+    Args:
+        embeddings: array-like of shape (n_samples, embedding_dim).
+        train_size: fraction in (0, 1) or absolute count for the training set.
+        metric: distance metric passed to ``scipy.spatial.distance.cdist``.
+        random_state: seeds the starting point (the traversal is otherwise
+            deterministic).
+
+    Returns:
+        train_indices: the denser interior remainder.
+        test_indices: a farthest-point-sampled, space-covering test set.
+    """
+    embeddings = validate_split_inputs(embeddings, train_size)
+    n_samples = len(embeddings)
+    n_test = n_samples - resolve_n_train(n_samples, train_size)
+    rng = check_random_state(random_state)
+
+    # TODO: Replace the full pairwise matrix with incremental NearestNeighbors
+    # queries to avoid materializing O(n²) distances.
+    distances = cdist(embeddings, embeddings, metric=metric)
+
+    start = int(rng.randint(n_samples))
+    selected = [start]
+    selected_mask = np.zeros(n_samples, dtype=bool)
+    selected_mask[start] = True
+    # Min distance from each point to the current test set; -1 marks selected.
+    min_dist = distances[start].copy()
+    min_dist[selected_mask] = -1.0
+    while len(selected) < n_test:
+        nxt = int(np.argmax(min_dist))
+        selected.append(nxt)
+        selected_mask[nxt] = True
+        min_dist = np.minimum(min_dist, distances[nxt])
+        min_dist[selected_mask] = -1.0
+
+    test_set = set(selected)
+    train = [i for i in range(n_samples) if i not in test_set]
+    return as_index_array(train), as_index_array(sorted(test_set))

--- a/splytters/grouped.py
+++ b/splytters/grouped.py
@@ -1,0 +1,166 @@
+"""
+Grouping-aware splits that keep related samples on the same side.
+
+These prevent train/test leakage from samples that must not be separated:
+explicit groups (same user / document / source) for :func:`group_split`, and
+discovered near-duplicates for :func:`deduplicated_split`. Unlike
+:func:`splytters.cluster_kfold`, the groups here are *given* (or derived from a
+similarity threshold), not discovered by clustering.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import numpy as np
+from numpy.typing import ArrayLike
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import connected_components
+from scipy.spatial.distance import cdist
+from sklearn.utils import check_random_state
+
+from splytters.utils import as_index_array, resolve_n_train, validate_split_inputs
+
+
+def _assign_whole_groups(
+    group_to_indices: dict, target_train: int, rng
+) -> tuple[list[int], list[int]]:
+    """Greedily assign whole groups to train (up to ``target_train``), rest to
+    test, so no group is split across sides. Guarantees both sides non-empty.
+    """
+    groups = [np.asarray(idxs) for idxs in group_to_indices.values()]
+    order = rng.permutation(len(groups))
+
+    train_groups: list[int] = []
+    test_groups: list[int] = []
+    filled = 0
+    for j in order:
+        if filled + len(groups[j]) <= target_train:
+            train_groups.append(j)
+            filled += len(groups[j])
+        else:
+            test_groups.append(j)
+
+    # Pathological case (e.g. one group larger than target_train): make sure
+    # train isn't empty by pulling the smallest test group over.
+    if not train_groups and test_groups:
+        smallest = min(test_groups, key=lambda j: len(groups[j]))
+        test_groups.remove(smallest)
+        train_groups.append(smallest)
+
+    train = [i for j in train_groups for i in groups[j].tolist()]
+    test = [i for j in test_groups for i in groups[j].tolist()]
+    return train, test
+
+
+def group_split(
+    embeddings: ArrayLike,
+    groups: ArrayLike,
+    train_size: float | int = 0.7,
+    random_state: int = 42,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Split so that every group lands entirely on one side (no group leakage).
+
+    All samples sharing a group id (e.g. the same user, document, patient, or
+    source) are kept together in either train or test. Whole groups are assigned
+    greedily to approach ``train_size`` by sample count. The analogue of
+    scikit-learn's :class:`~sklearn.model_selection.GroupShuffleSplit`, but on
+    embeddings and returning index arrays.
+
+    Args:
+        embeddings: array-like of shape (n_samples, embedding_dim) (used for
+            length/validation; the split is driven by ``groups``).
+        groups: group id per sample, shape (n_samples,).
+        train_size: fraction in (0, 1) or absolute count for the training set.
+            Approximate, since groups are indivisible.
+        random_state: for reproducibility.
+
+    Returns:
+        train_indices, test_indices.
+
+    Raises:
+        ValueError: on a ``groups``/embeddings length mismatch or fewer than two
+            distinct groups (nothing to split).
+    """
+    embeddings = validate_split_inputs(embeddings, train_size)
+    groups = np.asarray(groups)
+    n_samples = len(embeddings)
+    if len(groups) != n_samples:
+        raise ValueError(
+            f"groups has length {len(groups)} but embeddings has {n_samples} rows"
+        )
+    unique = np.unique(groups)
+    if len(unique) < 2:
+        raise ValueError(f"need at least 2 distinct groups to split, got {len(unique)}")
+
+    rng = check_random_state(random_state)
+    group_to_indices = {g: np.flatnonzero(groups == g) for g in unique}
+    target_train = resolve_n_train(n_samples, train_size)
+    train, test = _assign_whole_groups(group_to_indices, target_train, rng)
+    return as_index_array(sorted(train)), as_index_array(sorted(test))
+
+
+def deduplicated_split(
+    embeddings: ArrayLike,
+    train_size: float | int = 0.7,
+    similarity_threshold: float | None = None,
+    metric: str = "euclidean",
+    random_state: int = 42,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Split so that near-duplicates never straddle train and test.
+
+    Groups of near-duplicate samples (connected components of the graph linking
+    pairs within ``similarity_threshold``) are each assigned entirely to one
+    side, preventing the inflated scores that train/test duplicate leakage
+    causes. The inverse of :func:`splytters.duplicate_spread_split`, which
+    intentionally puts duplicates on *both* sides.
+
+    Args:
+        embeddings: array-like of shape (n_samples, embedding_dim).
+        train_size: fraction in (0, 1) or absolute count for the training set
+            (approximate, since duplicate groups are indivisible).
+        similarity_threshold: pairs closer than this (``metric`` distance) are
+            treated as near-duplicates. Defaults to the 1st percentile of
+            pairwise distances (conservative — only the closest pairs); raise it
+            to merge looser near-duplicates, lower it to merge only exact ones.
+        metric: distance metric passed to ``scipy.spatial.distance.cdist``.
+        random_state: for reproducibility.
+
+    Returns:
+        train_indices, test_indices.
+
+    Raises:
+        ValueError: if the threshold merges every sample into one near-duplicate
+            component (nothing left to split without leakage) — lower
+            ``similarity_threshold``.
+    """
+    embeddings = validate_split_inputs(embeddings, train_size)
+    n_samples = len(embeddings)
+    rng = check_random_state(random_state)
+
+    # TODO: Replace the full pairwise matrix with BallTree.query_radius to find
+    # near-duplicate pairs without materializing O(n²) distances.
+    distances = cdist(embeddings, embeddings, metric=metric)
+    np.fill_diagonal(distances, np.inf)
+    if similarity_threshold is None:
+        finite = distances[distances < np.inf]
+        similarity_threshold = np.percentile(finite, 1)
+
+    adjacency = (distances <= similarity_threshold).astype(int)
+    _, labels = connected_components(csr_matrix(adjacency))
+
+    component_to_indices: dict[int, list[int]] = defaultdict(list)
+    for idx, label in enumerate(labels):
+        component_to_indices[int(label)].append(idx)
+    if len(component_to_indices) < 2:
+        raise ValueError(
+            "similarity_threshold merged all samples into one near-duplicate "
+            "component; lower it to leave separable groups."
+        )
+
+    components = {k: np.asarray(v) for k, v in component_to_indices.items()}
+    target_train = resolve_n_train(n_samples, train_size)
+    train, test = _assign_whole_groups(components, target_train, rng)
+    return as_index_array(sorted(train)), as_index_array(sorted(test))

--- a/tests/test_grouped.py
+++ b/tests/test_grouped.py
@@ -1,0 +1,93 @@
+"""Tests for grouping-aware splits (group_split, deduplicated_split)."""
+
+import numpy as np
+import pytest
+
+from splytters import deduplicated_split, group_split
+
+
+def _valid(train, test, n):
+    s_tr, s_te = set(train.tolist()), set(test.tolist())
+    return (
+        (s_tr | s_te) == set(range(n))
+        and not (s_tr & s_te)
+        and len(train) > 0
+        and len(test) > 0
+    )
+
+
+class TestGroupSplit:
+
+    @pytest.fixture
+    def grouped_data(self):
+        rng = np.random.RandomState(0)
+        X = rng.randn(120, 8)
+        groups = np.repeat(np.arange(20), 6)  # 20 groups of 6
+        return X, groups
+
+    def test_valid_split(self, grouped_data):
+        X, groups = grouped_data
+        train, test = group_split(X, groups, train_size=0.7)
+        assert _valid(train, test, len(X))
+
+    def test_no_group_spans_both_sides(self, grouped_data):
+        X, groups = grouped_data
+        train, test = group_split(X, groups, train_size=0.7)
+        assert set(groups[train]) & set(groups[test]) == set()
+
+    def test_approximate_train_size(self, grouped_data):
+        X, groups = grouped_data
+        train, _ = group_split(X, groups, train_size=0.7)
+        assert abs(len(train) / len(X) - 0.7) < 0.15
+
+    def test_deterministic(self, grouped_data):
+        X, groups = grouped_data
+        a = group_split(X, groups, random_state=1)
+        b = group_split(X, groups, random_state=1)
+        assert np.array_equal(a[0], b[0]) and np.array_equal(a[1], b[1])
+
+    def test_length_mismatch_raises(self, grouped_data):
+        X, groups = grouped_data
+        with pytest.raises(ValueError, match="length"):
+            group_split(X, groups[:-1])
+
+    def test_single_group_raises(self):
+        X = np.random.RandomState(0).randn(10, 3)
+        with pytest.raises(ValueError, match="at least 2"):
+            group_split(X, np.zeros(10, dtype=int))
+
+
+class TestDeduplicatedSplit:
+
+    @pytest.fixture
+    def dup_data(self):
+        """Well-separated bases, each with one near-exact duplicate: pairs
+        (i, i + 60) are near-duplicates."""
+        rng = np.random.RandomState(0)
+        base = rng.randn(60, 8) * 10
+        return np.vstack([base, base + 1e-4])
+
+    def test_valid_split(self, dup_data):
+        train, test = deduplicated_split(
+            dup_data, train_size=0.7, similarity_threshold=0.1
+        )
+        assert _valid(train, test, len(dup_data))
+
+    def test_no_near_duplicate_pair_split(self, dup_data):
+        train, _ = deduplicated_split(
+            dup_data, train_size=0.7, similarity_threshold=0.1
+        )
+        trs = set(train.tolist())
+        for i in range(60):  # each (i, i+60) duplicate pair stays together
+            assert (i in trs) == ((i + 60) in trs)
+
+    def test_deterministic(self, dup_data):
+        a = deduplicated_split(dup_data, similarity_threshold=0.1, random_state=1)
+        b = deduplicated_split(dup_data, similarity_threshold=0.1, random_state=1)
+        assert np.array_equal(a[0], b[0]) and np.array_equal(a[1], b[1])
+
+    def test_all_one_component_raises(self):
+        """Identical points collapse to a single component — nothing to split."""
+        X = np.ones((10, 4))
+        with pytest.raises(ValueError, match="one near-duplicate component"):
+            deduplicated_split(X)

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -3,7 +3,7 @@
 import splytters
 import splytters.sorters as sorters
 
-SPLIT_FAMILIES = {"adversarial", "overlap", "balanced", "baseline"}
+SPLIT_FAMILIES = {"adversarial", "overlap", "balanced", "baseline", "grouped"}
 SORTER_MODALITIES = {"embedding", "text", "image", "audio", "tabular"}
 
 
@@ -42,6 +42,7 @@ def test_list_splitters_covers_every_registered_split():
         "splytters.adversarial",
         "splytters.overlap",
         "splytters.balanced",
+        "splytters.grouped",
     }
     actual = {
         n

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -14,6 +14,7 @@ from splytters.adversarial import (
     density_adversarial_split,
     distance_adversarial_split,
     get_cluster_info,
+    maximin_split,
     min_cut_split,
     minority_grow_split,
     minority_split,
@@ -650,6 +651,28 @@ class TestDecisionBoundarySplit:
         X, y = two_lines
         with pytest.raises(ValueError):
             decision_boundary_split(X, y, **kw)
+
+
+class TestMaximinSplit:
+    """Farthest-point (k-center) test selection — a diverse, spread-out test."""
+
+    def test_valid_split(self, embeddings_2d):
+        train, test = maximin_split(embeddings_2d, train_size=0.7)
+        assert_valid_split(train, test, len(embeddings_2d), ratio_tol=0.05)
+
+    def test_test_more_spread_than_random(self, embeddings_2d):
+        """The farthest-point test set is more diverse (larger mean pairwise
+        distance) than a random test set of the same size."""
+        from scipy.spatial.distance import pdist
+        _, m_te = maximin_split(embeddings_2d, train_size=0.7, random_state=0)
+        _, r_te = random_split(embeddings_2d, train_size=0.7, random_state=0)
+        assert pdist(embeddings_2d[m_te]).mean() > pdist(embeddings_2d[r_te]).mean()
+
+    def test_deterministic(self, embeddings_2d):
+        assert _splits_equal(
+            maximin_split(embeddings_2d, random_state=1),
+            maximin_split(embeddings_2d, random_state=1),
+        )
 
 
 class TestMMDMaximizedSplit:


### PR DESCRIPTION
Three new splitters covering objectives the library lacked:

- group_split (new `grouped` family): keep every sample sharing a group id (user/document/source) on one side — embedding analogue of sklearn's GroupShuffleSplit, preventing group leakage.
- deduplicated_split (grouped): assign each near-duplicate component entirely to one side so duplicates never straddle train/test (the inverse of duplicate_spread_split). Conservative 1st-percentile default threshold.
- maximin_split (adversarial): farthest-point/k-center test selection — a diverse, space-covering hard test set that never under-represents sparse/outlying regions.

Registered in __init__, the family registry, and the README inventory (also backfilled decision_boundary_split there). Tests cover validity, the no-leakage / diversity invariants, determinism, and errors.