### PR TITLE
fix: per_class_split seed forwarding and min_cut Fiedler sign

### DIFF
--- a/splytters/adversarial.py
+++ b/splytters/adversarial.py
@@ -1305,6 +1305,15 @@ def min_cut_split(
             # Fiedler vector (2nd eigenvector)
             fiedler = eigenvectors[:, 1]
 
+            # The Fiedler sign is mathematically arbitrary and, with eigsh's
+            # random start vector, flips between runs — which would flip which
+            # half of the cut becomes test (giving a completely different, seed-
+            # dependent held-out set). Orient it deterministically (sign of the
+            # largest-magnitude component, as in sklearn's svd_flip) so the split
+            # is reproducible.
+            if fiedler[np.argmax(np.abs(fiedler))] < 0:
+                fiedler = -fiedler
+
             # Partition by Fiedler vector values
             # Sort and split to achieve desired train_size
             sorted_indices = np.argsort(fiedler)

--- a/splytters/stratify.py
+++ b/splytters/stratify.py
@@ -11,6 +11,7 @@ in train (coverage 1.0), so only pure within-class structure is left.
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Iterator, Sequence
 from typing import Any
 
@@ -25,6 +26,17 @@ def _class_groups(y: np.ndarray) -> Iterator[tuple[Any, np.ndarray]]:
     """Yield ``(label, global_indices)`` for each unique label in ``y``."""
     for c in np.unique(y):
         yield c, np.flatnonzero(y == c)
+
+
+def _accepts_random_state(fn: Any) -> bool:
+    """Whether ``fn`` takes a ``random_state`` keyword (directly or via **kwargs)."""
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return True  # can't introspect (e.g. a C callable) — assume it does
+    if any(p.kind == p.VAR_KEYWORD for p in params.values()):
+        return True
+    return "random_state" in params
 
 
 def _take(data: Any, idx: np.ndarray) -> Any:
@@ -65,7 +77,11 @@ def per_class_split(
             than ``n_clusters``). ``"fallback"`` (default) falls back to a random
             split for that class so coverage is preserved; ``"raise"`` propagates
             the original error.
-        random_state: seed for the ``"fallback"`` random split.
+        random_state: seed forwarded to ``split_fn`` on every per-class call (so
+            it actually drives the wrapped splitter), and used for the
+            ``"fallback"`` random split. Deterministic splitters ignore it; a
+            custom ``split_fn`` that doesn't accept ``random_state`` is called
+            without it.
         **split_kwargs: forwarded to ``split_fn`` on every per-class call.
 
     Returns:
@@ -84,6 +100,13 @@ def per_class_split(
     if len(X) != len(y):
         raise ValueError(f"embeddings has {len(X)} rows but y has {len(y)} labels")
 
+    # Forward the seed to split_fn so per_class_split's random_state actually
+    # drives the wrapped splitter (deterministic splitters ignore it). Custom
+    # split_fns that don't accept random_state are called without it.
+    call_kwargs = dict(split_kwargs)
+    if _accepts_random_state(split_fn):
+        call_kwargs.setdefault("random_state", random_state)
+
     train: list[int] = []
     test: list[int] = []
     for _c, idx in _class_groups(y):
@@ -94,7 +117,7 @@ def per_class_split(
 
         class_emb = X[idx]
         try:
-            tr_local, te_local = split_fn(class_emb, train_size, **split_kwargs)
+            tr_local, te_local = split_fn(class_emb, train_size, **call_kwargs)
         except Exception:
             if on_error == "raise":
                 raise

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -761,6 +761,16 @@ class TestMinCutSplit:
         train, test = min_cut_split(embeddings_small, method="spectral")
         assert_valid_split(train, test, len(embeddings_small), ratio_tol=0.3)
 
+    def test_spectral_seed_independent(self):
+        """The Fiedler sign is oriented deterministically, so different seeds
+        give the identical split (previously the sign flip yielded disjoint
+        held-out sets)."""
+        rng = np.random.RandomState(0)
+        X = np.vstack([rng.randn(50, 10), rng.randn(50, 10) + 4])
+        a = min_cut_split(X, train_size=0.8, method="spectral", random_state=0)
+        b = min_cut_split(X, train_size=0.8, method="spectral", random_state=1)
+        assert _splits_equal(a, b)
+
     def test_tiny_dataset(self):
         X = np.array([[0, 0], [1, 1]])
         train, test = min_cut_split(X, train_size=0.5)

--- a/tests/test_stratify.py
+++ b/tests/test_stratify.py
@@ -64,6 +64,28 @@ class TestPerClassSplit:
         np.testing.assert_array_equal(a[0], b[0])
         np.testing.assert_array_equal(a[1], b[1])
 
+    def test_random_state_drives_wrapped_splitter(self, labeled_embeddings):
+        """random_state must reach split_fn (not just the fallback): a
+        seed-varying splitter gives different splits for different seeds, and the
+        same seed is reproducible."""
+        X, y = labeled_embeddings
+        a = per_class_split(cluster_split, X, y, 0.7, random_state=0, n_clusters=5)
+        b = per_class_split(cluster_split, X, y, 0.7, random_state=1, n_clusters=5)
+        c = per_class_split(cluster_split, X, y, 0.7, random_state=0, n_clusters=5)
+        assert not np.array_equal(a[1], b[1])          # seed changes the split
+        np.testing.assert_array_equal(a[1], c[1])       # same seed reproducible
+
+    def test_custom_split_fn_without_random_state(self, labeled_embeddings):
+        """A split_fn that doesn't accept random_state is called without it."""
+        X, y = labeled_embeddings
+
+        def custom(emb, train_size=0.7):
+            k = int(len(emb) * train_size)
+            return np.arange(k), np.arange(k, len(emb))
+
+        train, test = per_class_split(custom, X, y, 0.7, random_state=0)
+        assert _is_partition(train, test, len(X))
+
     def test_fallback_on_small_class(self):
         """cluster_split(n_clusters=10) fails on a 4-sample class; fallback saves it."""
         rng = np.random.RandomState(1)


### PR DESCRIPTION
Two independent determinism bugs:

- per_class_split never forwarded random_state to split_fn (its named random_state only seeded the rare fallback), so the wrapped splitter was pinned to its default seed and per_class_split's random_state was inert. Now forwarded, guarded by a signature check so a custom split_fn that doesn't take random_state is still called without it.

- min_cut_split (spectral) sorted by the Fiedler vector, whose sign is arbitrary and flips with eigsh's random start vector — flipping which half of the cut becomes test and producing completely disjoint held-out sets between seeds. Orient the sign deterministically (largest-magnitude component, like sklearn's svd_flip) so the split is reproducible.

Each has a regression test.