### PR TITLE
docs(splitters): add seed-stability notes to each splitter docstring

### DIFF
--- a/splytters/adversarial.py
+++ b/splytters/adversarial.py
@@ -249,6 +249,11 @@ def cluster_split(
         class-balancing with a linear program (with convergence guarantees).
         https://openreview.net/forum?id=Q692C0WtiD . See
         :func:`mmd_maximized_split` for the MMD-maximizing objective.
+
+    Seed stability: varies with the seed -- the KMeans clustering, and which
+    whole clusters are held out, shift with the seed, so the test set can differ
+    substantially between runs (from near-identical to nearly disjoint) even
+    though the clusters themselves are similar.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
 
@@ -327,6 +332,10 @@ def centroid_adversarial_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed -- built on KMeans clustering, so which
+    whole clusters land in test shifts between seeds and the held-out set can
+    change substantially.
     """
     return cluster_split(
         embeddings,
@@ -389,6 +398,10 @@ def cluster_kfold(
         Clustering-Based Data Splits for Model Performance Evaluation," Eval4NLP
         @ COLING -- folds that are lexically distinct from train while preserving
         label balance. https://aclanthology.org/2020.eval4nlp-1.15
+
+    Seed stability: structure-stable -- fold assignment varies with the KMeans
+    clustering, though the cluster-coherent, label-balanced structure is
+    preserved.
     """
     embeddings = validate_split_inputs(embeddings, 0.5)  # 0.5: unused placeholder
     y = np.asarray(y)
@@ -527,6 +540,9 @@ def minority_split(
         anti-biased (test). Their other two notions -- dataset cartography
         (training dynamics) and partial-input models -- are model-in-the-loop /
         task-specific and out of scope for a static splitter.
+
+    Seed stability: nearly deterministic -- the per-cluster minority labels are
+    stable; only the underlying KMeans clustering wobbles slightly between seeds.
     """
     embeddings = validate_split_inputs(embeddings, 0.5)  # 0.5: unused placeholder
     y = np.asarray(y)
@@ -771,6 +787,10 @@ def minority_grow_split(
         Extends the bias-amplified minority seed of Reif & Schwartz (2023); see
         :func:`minority_split`. The proximity growth is the single-linkage region
         growth also used by ``cluster_split(strategy="closest")``.
+
+    Seed stability: nearly deterministic -- the minority seeds and proximity
+    growth are largely fixed; only the underlying clustering wobbles between
+    seeds. This holds in every ``stratify`` mode (none / global / per-class).
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     y = np.asarray(y)
@@ -906,6 +926,10 @@ def class_boundary_split(
         toward *other classes* rather than toward the training set, yielding a
         boundary-focused test set; contrast :func:`distance_adversarial_split`
         (unsupervised, distance from the global centroid).
+
+    Seed stability: deterministic -- closeness to other classes is a fixed
+    geometric quantity, so the seed has no effect (it is accepted only for API
+    consistency).
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     y = np.asarray(y)
@@ -1009,6 +1033,11 @@ def decision_boundary_split(
         (2021), "We Need to Talk About Random Splits"
         (https://aclanthology.org/2021.eacl-main.156), but using a *learned*
         boundary rather than embedding geometry.
+
+    Seed stability: structure-stable -- the cross-validation folds depend on the
+    seed, so which samples sit nearest the learned boundary (and go to test)
+    shifts somewhat between seeds. This holds in both ``stratify`` modes
+    (per-class and global wobble about equally).
     """
     from sklearn.linear_model import LogisticRegression
     from sklearn.model_selection import StratifiedKFold
@@ -1128,6 +1157,10 @@ def distance_adversarial_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: deterministic -- samples are ranked by distance from the
+    centroid, so the seed has no effect (it is accepted only for API
+    consistency).
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     centroid = compute_centroid(embeddings)
@@ -1167,6 +1200,9 @@ def density_adversarial_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: deterministic -- samples are ranked by local density, so the
+    seed has no effect.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
 
@@ -1210,6 +1246,9 @@ def outlier_adversarial_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: nearly deterministic -- the outlier ranking is fixed; only
+    samples right at the train/test cutoff can change between seeds.
     """
     from sklearn.ensemble import IsolationForest
 
@@ -1260,6 +1299,12 @@ def min_cut_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: deterministic (spectral method) -- the split follows the
+    Fiedler vector, whose otherwise-arbitrary sign is oriented deterministically,
+    so it does not depend on the random ``eigsh`` start vector. (Without that
+    orientation the held-out half would flip with the sign, giving disjoint test
+    sets between seeds.)
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_samples = len(embeddings)
@@ -1416,6 +1461,9 @@ def normalized_cut_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: deterministic -- the normalized-cut partition uses a dense
+    eigendecomposition (eigh), which is fixed, so the seed has no effect.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_samples = len(embeddings)
@@ -1484,6 +1532,9 @@ def wasserstein_adversarial_split(
         Filippova (2021), "We Need to Talk About Random Splits," EACL, which
         constructs hard splits by (approximately) maximizing the Wasserstein
         distance between train and test. https://aclanthology.org/2021.eacl-main.156
+
+    Seed stability: varies with the seed like a random split -- the test pocket
+    is grown around a randomly chosen anchor point.
     """
     from scipy.stats import wasserstein_distance
     from sklearn.neighbors import NearestNeighbors
@@ -1554,6 +1605,10 @@ def mmd_maximized_split(
         programming to preserve class/group balance, with convergence guarantees
         and Nyström scaling. For class-balanced clustering splits, see
         ``cluster_split(strategy="subset_sum")`` and :func:`cluster_kfold`.
+
+    Seed stability: varies with the seed like a random split -- the swap
+    optimization starts from a random split and many assignments reach a similar
+    MMD, so the chosen test set differs run to run.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_dims = embeddings.shape[1]
@@ -1652,6 +1707,10 @@ def maximin_split(
     Returns:
         train_indices: the denser interior remainder.
         test_indices: a farthest-point-sampled, space-covering test set.
+
+    Seed stability: structure-stable -- only the starting point of the
+    farthest-first traversal is random, so different seeds give overlapping but
+    not identical space-covering test sets.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_samples = len(embeddings)

--- a/splytters/balanced.py
+++ b/splytters/balanced.py
@@ -43,6 +43,10 @@ def distribution_matched_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- the swap
+    optimization starts from a random split and many assignments match the
+    distribution equally well.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
 
@@ -79,6 +83,9 @@ def moment_matched_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- the swap
+    optimization reaches different assignments with equally matched moments.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
 
@@ -117,6 +124,9 @@ def histogram_matched_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- the swap
+    optimization reaches different assignments with equally matched histograms.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_dims = embeddings.shape[1]
@@ -163,6 +173,9 @@ def stratified_random_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- it is a seeded
+    stratified random draw.
     """
     from sklearn.model_selection import train_test_split
 
@@ -200,6 +213,9 @@ def density_balanced_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- samples are
+    shuffled within each density bin before the proportional split.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_samples = len(embeddings)
@@ -270,6 +286,9 @@ def mmd_minimized_split(
         (2025), "Clustering-Based Validation Splits for Model Selection under
         Domain Shift," TMLR (https://openreview.net/forum?id=Q692C0WtiD). See
         :func:`splytters.mmd_maximized_split`.
+
+    Seed stability: varies with the seed like a random split -- the swap
+    optimization reaches different assignments with similarly low MMD.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_dims = embeddings.shape[1]

--- a/splytters/grouped.py
+++ b/splytters/grouped.py
@@ -82,6 +82,10 @@ def group_split(
     Raises:
         ValueError: on a ``groups``/embeddings length mismatch or fewer than two
             distinct groups (nothing to split).
+
+    Seed stability: varies with the seed like a random split -- whole groups are
+    assigned to train/test in a random (seeded) order, though each group always
+    stays intact.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     groups = np.asarray(groups)
@@ -135,6 +139,9 @@ def deduplicated_split(
         ValueError: if the threshold merges every sample into one near-duplicate
             component (nothing left to split without leakage) — lower
             ``similarity_threshold``.
+
+    Seed stability: structure-stable -- the near-duplicate groups are fixed; only
+    which group goes to which side is random.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_samples = len(embeddings)

--- a/splytters/overlap.py
+++ b/splytters/overlap.py
@@ -50,6 +50,9 @@ def cluster_leak_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- each cluster is
+    shuffled before being split, so which members go to test differs run to run.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     rng = check_random_state(random_state)
@@ -100,6 +103,9 @@ def neighbor_coverage_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- it starts from a
+    random train set and admits/swaps points stochastically.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_samples = len(embeddings)
@@ -182,6 +188,9 @@ def centroid_matched_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- the swap
+    optimization has many assignments with equally matched centroids.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
 
@@ -216,6 +225,9 @@ def stratified_similarity_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- samples are
+    shuffled within each distance bin before the proportional split.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     rng = check_random_state(random_state)
@@ -270,6 +282,9 @@ def nearest_neighbor_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- points are
+    processed in a random order when building the test set.
     """
     from sklearn.neighbors import NearestNeighbors
 
@@ -331,6 +346,9 @@ def duplicate_spread_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- each
+    near-duplicate group is shuffled before being split across both sides.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     rng = check_random_state(random_state)
@@ -404,6 +422,9 @@ def max_coverage_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: varies with the seed like a random split -- it starts from a
+    random split and greedily swaps, reaching different high-coverage solutions.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_samples = len(embeddings)

--- a/splytters/stratify.py
+++ b/splytters/stratify.py
@@ -91,6 +91,11 @@ def per_class_split(
     Raises:
         ValueError: if ``embeddings`` and ``y`` differ in length, or ``on_error``
             is not ``"fallback"`` or ``"raise"``.
+
+    Seed stability: inherits ``split_fn``'s character -- wrapping a deterministic
+    splitter per class stays deterministic; wrapping a seed-varying one stays
+    seed-varying. Applying a splitter per class vs globally changes *which*
+    samples are selected, but not its determinism.
     """
     if on_error not in ("fallback", "raise"):
         raise ValueError(f"on_error must be 'fallback' or 'raise', got {on_error!r}")

--- a/splytters/utils.py
+++ b/splytters/utils.py
@@ -221,6 +221,10 @@ def random_split(
     Returns:
         train_indices: ndarray of indices for training set
         test_indices: ndarray of indices for test set
+
+    Seed stability: fully random -- every seed gives a different train/test
+    split; this is the baseline the other splitters' seed stability is measured
+    against.
     """
     embeddings = validate_split_inputs(embeddings, train_size)
     n_samples = len(embeddings)


### PR DESCRIPTION
Classify every splitter by how much its held-out set changes across random seeds (measured as pairwise test-set Jaccard over multiple seeds vs the ~0.17 random baseline): deterministic (seed ignored), structure-stable, or varies-like-random. Notes reflect the mechanism (fixed geometric ranking vs KMeans vs random-init optimization) and, for stratify-mode splitters, that per-class and global share the same stability tier.

Depends on the seed-forwarding / Fiedler-sign fixes already on main.